### PR TITLE
Refactor/listener redesign

### DIFF
--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -69,7 +69,7 @@ def on_keyboard_event(event_type, key):
     print(f"Keyboard event: {event_type}, {key}")
 
 keyboard_listener = LISTENERS["keyboard"]()
-keyboard_listener.configure(on_keyboard_event)
+keyboard_listener.configure(callback=on_keyboard_event)
 keyboard_listener.activate()
 
 time.sleep(5)

--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -10,7 +10,7 @@ Open World Agents leverages a registration pattern that allows multiple modules 
 
 - **Registry:**
   - **CALLABLES:** Stores module-provided functionalities as key-value pairs (e.g., registered as `clock.time_ns`). What developer must implement is just `__call__` function.
-  - **LISTENERS:** Manages classes responsible for event handling by storing them under designated keys (e.g., registered as `clock/tick`). This class takes `callback` as argument in `__init__` and otherwise it's same as `Runnables`.
+  - **LISTENERS:** Manages classes responsible for event handling by storing them under designated keys (e.g., registered as `clock/tick`). This class takes `callback` as argument in `configure` and otherwise it's same as `Runnables`.
   - **RUNNABLES:** This is parent class of `Listeners` and it supports `start/stop/join` operations in user side and developer must implement `loop/cleanup` methods.
 
 Modules are activated via the `activate_module` function, during which their functions and listeners are systematically added to the global registry.

--- a/docs/env/plugins/std.md
+++ b/docs/env/plugins/std.md
@@ -30,8 +30,8 @@ print(f"Current time (ns): {current_time_ns}")
 def on_tick():
     print(f"Tick at {CALLABLES['clock.time_ns']()}")
 
-tick_listener = LISTENERS["clock/tick"](on_tick)
-tick_listener.configure(interval=1)  # Tick every second
+tick_listener = LISTENERS["clock/tick"]()
+tick_listener.configure(callback=on_tick, interval=1)  # Tick every second
 tick_listener.start()
 
 # Run for a few seconds to see the tick listener in action
@@ -71,8 +71,7 @@ def tick_callback():
     print(f"Tick at {CALLABLES['clock.time_ns']()}")
 
 # Configure and start the tick listener
-tick_listener = LISTENERS["clock/tick"]().configure(callback=tick_callback)
-tick_listener.configure(interval=1)
+tick_listener = LISTENERS["clock/tick"]().configure(callback=tick_callback, interval=1)
 tick_listener.start()
 
 # Let the listener run for 5 seconds

--- a/docs/env/plugins/std.md
+++ b/docs/env/plugins/std.md
@@ -71,7 +71,7 @@ def tick_callback():
     print(f"Tick at {CALLABLES['clock.time_ns']()}")
 
 # Configure and start the tick listener
-tick_listener = LISTENERS["clock/tick"](tick_callback)
+tick_listener = LISTENERS["clock/tick"]().configure(callback=tick_callback)
 tick_listener.configure(interval=1)
 tick_listener.start()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ With open-world-agents, you can:
         print(f"Current time in nanoseconds: {time_ns}")
 
     # Create a listener for clock/tick event
-    tick = LISTENERS["clock/tick"](callback)
+    tick = LISTENERS["clock/tick"]().configure(callback=callback)
 
     # Set listener to trigger every 1 second
     tick.configure(interval=1)
@@ -76,7 +76,7 @@ activate_module("your-own-envplugin")
 def callback(event):
     print(f"Captured event: {event}")
 
-listener = LISTENERS["my/listener"](callback)
+listener = LISTENERS["my/listener"]().configure(callback=callback)
 listener.configure(), listener.start()
 
 ... # Run any your own logic here. listener is being executed in background as thread(ListenerThread) or process(ListenerProcess).

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,7 +41,7 @@
         print(f"Current time in nanoseconds: {time_ns}")
 
     # Create a listener for clock/tick event
-    tick = LISTENERS["clock/tick"](callback)
+    tick = LISTENERS["clock/tick"]().configure(callback=callback)
 
     # Set listener to trigger every 1 second
     tick.configure(interval=1)

--- a/projects/core/main.py
+++ b/projects/core/main.py
@@ -12,7 +12,7 @@ print(CALLABLES, LISTENERS)
 # {'clock.time_ns': <built-in function time_ns>} {'clock/tick': <class 'owa.env.std.clock.ClockTickListener'>}
 
 # now, let's test the clock/tick listener
-tick = LISTENERS["clock/tick"](lambda: print(CALLABLES["clock.time_ns"]()))
+tick = LISTENERS["clock/tick"]().configure(callback=lambda: print(CALLABLES["clock.time_ns"]()))
 tick.configure(interval=1)
 tick.start()
 

--- a/projects/core/owa/callable.py
+++ b/projects/core/owa/callable.py
@@ -3,8 +3,9 @@ Callable implements `__call__` method, which allows the object to be called as a
 """
 
 from typing import Callable  # noqa
+from abc import ABC, abstractmethod
 
 
-class CallableMixin:
-    def __call__(self):
-        raise NotImplementedError
+class CallableMixin(ABC):
+    @abstractmethod
+    def __call__(self): ...

--- a/projects/core/owa/env/std/clock.py
+++ b/projects/core/owa/env/std/clock.py
@@ -11,7 +11,7 @@ S_TO_NS = 1_000_000_000
 # tick listener
 @LISTENERS.register("clock/tick")
 class ClockTickListener(Listener):
-    def configure(self, *, interval=1):
+    def on_configure(self, *, interval=1):
         self.interval = interval * S_TO_NS
 
     def loop(self):

--- a/projects/core/owa/listener.py
+++ b/projects/core/owa/listener.py
@@ -34,7 +34,7 @@ class ListenerMixin(RunnableMixin):
     def configure(self, *args, callback: Callable, **kwargs) -> Self:
         """Configure the listener with a callback function. `callback` keyword argument is reserved for the callback function."""
         self.register_callback(callback)
-        self.on_configure(*args, **kwargs)
+        super().configure(*args, **kwargs)
         return self
 
 

--- a/projects/core/owa/listener.py
+++ b/projects/core/owa/listener.py
@@ -11,19 +11,37 @@
 #     - while the Listener class provides the interface for the environment to call the user-defined function.
 
 
+from typing import Self
+
 from .callable import Callable
-from .runnable import RunnableMixin, RunnableThread
+from .runnable import RunnableMixin, RunnableProcess, RunnableThread
 
 
 class ListenerMixin(RunnableMixin):
     """ListenerMixin provides the interface for the environment to call the user-defined function."""
 
-    def __init__(self, callback: Callable, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.callback = callback
+    def get_callback(self) -> Callable:
+        if not hasattr(self, "_callback"):
+            raise AttributeError("Callback not set. Please call self.register_callback() to set the callback.")
+        return self._callback
+
+    def register_callback(self, callback: Callable) -> Self:
+        self._callback = callback
+        return self
+
+    callback = property(get_callback, register_callback)
+
+    def configure(self, *args, callback: Callable, **kwargs) -> Self:
+        """Configure the listener with a callback function. `callback` keyword argument is reserved for the callback function."""
+        self.register_callback(callback)
+        self.on_configure(*args, **kwargs)
+        return self
 
 
 class ListenerThread(ListenerMixin, RunnableThread): ...
+
+
+class ListenerProcess(ListenerMixin, RunnableProcess): ...
 
 
 Listener = ListenerThread  # Default to ListenerThread

--- a/projects/core/owa/runnable.py
+++ b/projects/core/owa/runnable.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import threading
 from abc import ABC, abstractmethod
+from typing import Self
 
 
 class RunnableMixin(ABC):
@@ -29,9 +30,22 @@ class RunnableMixin(ABC):
     @abstractmethod
     def is_alive(self): ...
 
+    # What is implemented
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        self.join()
+
+    def configure(self, *args, **kwargs) -> Self:
+        self.on_configure(*args, **kwargs)
+        return self
+
     # What user implements
-    def configure(self):
-        """Optional method for configuration."""
+    def on_configure(self):
+        """Optional method for configuration. This method is called when self.configure() is called."""
 
     @abstractmethod
     def loop(self):
@@ -57,8 +71,8 @@ class RunnableThread(threading.Thread, RunnableMixin):
         self._stop_event.set()
 
     # What user implements
-    def configure(self):
-        """Optional method for configuration."""
+    def on_configure(self):
+        """Optional method for configuration. This method is called when self.configure() is called."""
 
     @abstractmethod
     def loop(self):
@@ -84,8 +98,8 @@ class RunnableProcess(multiprocessing.Process, RunnableMixin):
         self._stop_event.set()
 
     # What user implements
-    def configure(self):
-        """Optional method for configuration."""
+    def on_configure(self):
+        """Optional method for configuration. This method is called when self.configure() is called."""
 
     @abstractmethod
     def loop(self):

--- a/projects/core/owa/runnable.py
+++ b/projects/core/owa/runnable.py
@@ -41,6 +41,7 @@ class RunnableMixin(ABC):
 
     def configure(self, *args, **kwargs) -> Self:
         self.on_configure(*args, **kwargs)
+        self._configured = True
         return self
 
     # What user implements
@@ -62,6 +63,8 @@ class RunnableThread(threading.Thread, RunnableMixin):
         self._stop_event = threading.Event()
 
     def run(self):
+        if not getattr(self, "_configured", False):
+            raise RuntimeError("RunnableThread is not configured. Call configure() before start().")
         try:
             self.loop()
         finally:
@@ -89,6 +92,8 @@ class RunnableProcess(multiprocessing.Process, RunnableMixin):
         self._stop_event = multiprocessing.Event()
 
     def run(self):
+        if not getattr(self, "_configured", False):
+            raise RuntimeError("RunnableProcess is not configured. Call configure() before start().")
         try:
             self.loop()
         finally:

--- a/projects/core/owa/runnable.py
+++ b/projects/core/owa/runnable.py
@@ -64,7 +64,9 @@ class RunnableThread(threading.Thread, RunnableMixin):
 
     def run(self):
         if not getattr(self, "_configured", False):
-            raise RuntimeError("RunnableThread is not configured. Call configure() before start().")
+            raise RuntimeError(
+                "RunnableThread is not configured. Call configure() before start(). Or you may have overriden the configure method, not on_configure."
+            )
         try:
             self.loop()
         finally:

--- a/projects/core/tests/env/test_std.py
+++ b/projects/core/tests/env/test_std.py
@@ -21,11 +21,9 @@ def test_clock():
         called_time.append(CALLABLES["clock.time_ns"]())
         print(called_time)
 
-    tick: Listener = LISTENERS["clock/tick"](callback)
+    tick = LISTENERS["clock/tick"]().configure(callback=callback, interval=1)
 
     called_time = []
-
-    tick.configure(interval=1)
     tick.start()
 
     time.sleep(1.5)

--- a/projects/core/tests/env/test_std.py
+++ b/projects/core/tests/env/test_std.py
@@ -2,7 +2,6 @@ import time
 
 import pytest
 
-from owa.listener import Listener
 from owa.registry import CALLABLES, LISTENERS, activate_module
 
 

--- a/projects/core/tests/test_runnable.py
+++ b/projects/core/tests/test_runnable.py
@@ -22,7 +22,7 @@ class MyProcessTest(RunnableProcess):
 @pytest.mark.timeout(2)
 def test_my_thread():
     """Test creation, start, and stop of a RunnableThread."""
-    t = MyThreadTest()
+    t = MyThreadTest().configure()
     t.start()
     # Wait a few seconds to confirm it is in the running state
     t.join(1)
@@ -36,7 +36,7 @@ def test_my_thread():
 @pytest.mark.timeout(2)
 def test_my_process():
     """Test creation, start, and stop of a RunnableProcess."""
-    p = MyProcessTest()
+    p = MyProcessTest().configure()
     p.start()
     # Wait a few seconds to confirm it is in the running state
     p.join(1)

--- a/projects/data_collection/recorder.py
+++ b/projects/data_collection/recorder.py
@@ -89,8 +89,8 @@ def main(
 
     configure()
     recorder = RUNNABLES["screen/recorder"]()
-    keyboard_listener = LISTENERS["keyboard"](control_publisher_callback)
-    mouse_listener = LISTENERS["mouse"](control_publisher_callback)
+    keyboard_listener = LISTENERS["keyboard"]().configure(callback=control_publisher_callback)
+    mouse_listener = LISTENERS["mouse"]().configure(callback=control_publisher_callback)
     recorder.configure(
         filesink_location=file_location,
         record_audio=record_audio,
@@ -101,8 +101,6 @@ def main(
         monitor_idx=monitor_idx,
         additional_args=additional_args,
     )
-    keyboard_listener.configure()
-    mouse_listener.configure()
 
     try:
         # TODO?: add `wait` method to Runnable, which waits until the Runnable is ready to operate well.

--- a/projects/owa-env-desktop/owa_env_desktop/keyboard_mouse/listeners.py
+++ b/projects/owa-env-desktop/owa_env_desktop/keyboard_mouse/listeners.py
@@ -10,7 +10,7 @@ from ..utils import key_to_vk
 
 @LISTENERS.register("keyboard")
 class KeyboardListenerWrapper(Listener):
-    def configure(self):
+    def on_configure(self):
         self.listener = KeyboardListener(on_press=self.on_press, on_release=self.on_release)
 
     def on_press(self, key):
@@ -32,7 +32,7 @@ class KeyboardListenerWrapper(Listener):
 
 @LISTENERS.register("mouse")
 class MouseListenerWrapper(Listener):
-    def configure(self):
+    def on_configure(self):
         self.listener = MouseListener(on_move=self.on_move, on_click=self.on_click, on_scroll=self.on_scroll)
 
     def on_move(self, x, y):

--- a/projects/owa-env-desktop/tests/test_all.py
+++ b/projects/owa-env-desktop/tests/test_all.py
@@ -73,8 +73,7 @@ def test_keyboard_listener():
         received_events.append((event_type, key))
 
     # Create and configure the listener.
-    keyboard_listener = LISTENERS["keyboard"](on_keyboard_event)
-    keyboard_listener.configure()
+    keyboard_listener = LISTENERS["keyboard"]().configure(callback=on_keyboard_event)
     keyboard_listener.start()
 
     # In a real-world scenario, the listener would capture actual events.

--- a/projects/owa-env-example/owa_env_example/example_listener.py
+++ b/projects/owa-env-example/owa_env_example/example_listener.py
@@ -8,7 +8,7 @@ class ExampleListener(Listener):
     This listener must implement the `loop` and `cleanup` methods.
 
     Within the listener, call `self.callback` to notify the environment of an event.
-    The `callback` function is provided as an argument to `__init__` and stored as `self.callback`.
+    The `callback` function is provided as an argument to `configure` and stored as `self.callback`.
     """
 
     def on_configure(self):

--- a/projects/owa-env-example/owa_env_example/example_listener.py
+++ b/projects/owa-env-example/owa_env_example/example_listener.py
@@ -11,8 +11,8 @@ class ExampleListener(Listener):
     The `callback` function is provided as an argument to `__init__` and stored as `self.callback`.
     """
 
-    def configure(self):
-        """Optional method for configuration."""
+    def on_configure(self):
+        """Optional method for configuration. This method is called when self.configure() is called."""
 
     def loop(self):
         """Main loop. This method must be interruptable by calling stop(), which sets the self._stop_event."""

--- a/projects/owa-env-example/owa_env_example/example_runnable.py
+++ b/projects/owa-env-example/owa_env_example/example_runnable.py
@@ -8,8 +8,8 @@ class ExampleRunnable(Runnable):
     Runnable must implement the `loop` and `cleanup` methods.
     """
 
-    def configure(self):
-        """Optional method for configuration."""
+    def on_configure(self):
+        """Optional method for configuration. This method is called when self.configure() is called."""
 
     def loop(self):
         """Main loop. This method must be interruptable by calling stop(), which sets the self._stop_event."""

--- a/projects/owa-env-gst/owa_env_gst/recorder.py
+++ b/projects/owa-env-gst/owa_env_gst/recorder.py
@@ -9,6 +9,7 @@ from loguru import logger
 from owa import Runnable
 from owa.registry import RUNNABLES
 
+from . import get_executable_path
 from .gst_factory import recorder_pipeline
 
 
@@ -34,7 +35,7 @@ def disable_ctrl_c_once():
 class ScreenRecorder(Runnable):
     """A ScreenRecorder Runnable that records video and/or audio using a GStreamer pipeline."""
 
-    def configure(
+    def on_configure(
         self,
         filesink_location: str,
         record_audio: bool = True,

--- a/projects/owa-env-gst/owa_env_gst/recorder.py
+++ b/projects/owa-env-gst/owa_env_gst/recorder.py
@@ -57,6 +57,9 @@ class ScreenRecorder(Runnable):
             Path(filesink_location).parent.mkdir(parents=True, exist_ok=True)
             logger.warning(f"Output directory {filesink_location} does not exist. Creating it.")
 
+        # convert to posix path. this is required for gstreamer executable.
+        filesink_location = Path(filesink_location).as_posix()
+
         pipeline_description = recorder_pipeline(
             filesink_location=filesink_location,
             record_audio=record_audio,

--- a/projects/owa-env-gst/owa_env_gst/recorder.py
+++ b/projects/owa-env-gst/owa_env_gst/recorder.py
@@ -9,7 +9,6 @@ from loguru import logger
 from owa import Runnable
 from owa.registry import RUNNABLES
 
-from . import get_executable_path
 from .gst_factory import recorder_pipeline
 
 

--- a/projects/owa-env-gst/owa_env_gst/screen/listeners.py
+++ b/projects/owa-env-gst/owa_env_gst/screen/listeners.py
@@ -13,7 +13,7 @@ import numpy as np
 from gi.repository import GLib, Gst
 from loguru import logger
 
-from owa import Callable, Listener
+from owa import Listener
 from owa.registry import LISTENERS
 
 from ..gst_factory import screen_capture_pipeline

--- a/projects/owa-env-gst/owa_env_gst/screen/listeners.py
+++ b/projects/owa-env-gst/owa_env_gst/screen/listeners.py
@@ -132,7 +132,7 @@ class ScreenListener(Listener):
         ret = self.pipeline.set_state(Gst.State.PLAYING)
         if ret == Gst.StateChangeReturn.FAILURE:
             bus = self.pipeline.get_bus()
-            msg = bus.timed_pop_filtered(Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR)
+            msg = bus.timed_pop_filtered(Gst.SECOND * 1.0, Gst.MessageType.ERROR)
             if msg:
                 err, debug = msg.parse_error()
                 logger.error(f"Failed to set pipeline to PLAYING state: {err} ({debug})")

--- a/projects/owa-env-gst/owa_env_gst/screen/listeners.py
+++ b/projects/owa-env-gst/owa_env_gst/screen/listeners.py
@@ -32,13 +32,6 @@ class ScreenListener(Listener):
     the second one will be this ScreenListener instance.
     """
 
-    def __init__(self, callback: Callable[[FrameStamped], None]):
-        super().__init__(callback=callback)
-        self.pipeline = None
-        self.appsink = None
-        self._loop = None
-        self._metric_queue = None
-
     @property
     def gst_latency(self):
         """
@@ -92,7 +85,7 @@ class ScreenListener(Listener):
         elapsed_time = end_time - start_time
         return len(self._metric_queue.queue) / (elapsed_time / Gst.SECOND)
 
-    def configure(
+    def on_configure(
         self,
         *,
         show_cursor: bool = True,

--- a/projects/owa-env-gst/owa_env_gst/screen/runnable.py
+++ b/projects/owa-env-gst/owa_env_gst/screen/runnable.py
@@ -33,7 +33,7 @@ class ScreenCapture(RunnableThread):
         self.queue = Queue(maxsize=1)  # Holds the most recent frame
         self.listener = None  # Listener for capturing screen frames
 
-    def configure(self, *, fps: float = 60, window_name: str | None = None, monitor_idx: int | None = None):
+    def on_configure(self, *, fps: float = 60, window_name: str | None = None, monitor_idx: int | None = None):
         """
         Configure and start the screen listener.
 
@@ -42,8 +42,8 @@ class ScreenCapture(RunnableThread):
             window_name (str | None): Name of the window to capture (optional).
             monitor_idx (int | None): Index of the monitor to capture (optional).
         """
-        self.listener = ScreenListener(callback=self.on_frame)
-        self.listener.configure(fps=fps, window_name=window_name, monitor_idx=monitor_idx)
+        self.listener = ScreenListener()
+        self.listener.configure(fps=fps, window_name=window_name, monitor_idx=monitor_idx, callback=self.on_frame)
         self.listener.start()
 
     def on_frame(self, frame):

--- a/projects/owa-env-gst/pyproject.toml
+++ b/projects/owa-env-gst/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "owa-core",
+    "pygobject-stubs>=2.12.0",
 ]
 
 [tool.uv.sources]

--- a/projects/owa-env-gst/scripts/benchmark_screen_captures.py
+++ b/projects/owa-env-gst/scripts/benchmark_screen_captures.py
@@ -217,8 +217,8 @@ def capture_owa_listener():
         nonlocal count
         count += 1
 
-    screen_capture = LISTENERS["screen"](callback)
-    screen_capture.configure(**owa_args)
+    screen_capture = LISTENERS["screen"]()
+    screen_capture.configure(**owa_args, callback=callback)
     screen_capture.start()
 
     # Warm-up period

--- a/projects/owa-env-gst/tests/test_screen_capture.py
+++ b/projects/owa-env-gst/tests/test_screen_capture.py
@@ -8,9 +8,8 @@ from owa.registry import RUNNABLES, activate_module
 @pytest.fixture(scope="module")
 def screen_capture():
     activate_module("owa_env_gst")
-    capture = RUNNABLES["screen_capture"]()
+    capture = RUNNABLES["screen_capture"]().configure(fps=30)
     capture.start()
-    capture.configure(fps=60)
     yield capture
     capture.stop()
     capture.join()

--- a/projects/owa-env-gst/tests/test_screen_listener.py
+++ b/projects/owa-env-gst/tests/test_screen_listener.py
@@ -17,8 +17,7 @@ def test_screen_capture():
         assert frame.frame_arr.ndim == 3 and frame.frame_arr.shape[2] == 4, "Expected 4-color channel image"
         print(frame.frame_arr.shape, listener.fps, listener.latency)
 
-    screen_listener = LISTENERS["screen"](callback)
-    screen_listener.configure()
+    screen_listener = LISTENERS["screen"]().configure(callback=callback)
     screen_listener.start()
     time.sleep(2)
     screen_listener.stop()

--- a/projects/owa-env-gst/uv.lock
+++ b/projects/owa-env-gst/uv.lock
@@ -129,10 +129,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "owa-core" },
+    { name = "pygobject-stubs" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "owa-core", editable = "../core" }]
+requires-dist = [
+    { name = "owa-core", editable = "../core" },
+    { name = "pygobject-stubs", specifier = ">=2.12.0" },
+]
 
 [[package]]
 name = "pydantic"
@@ -200,6 +204,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
     { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
 ]
+
+[[package]]
+name = "pygobject-stubs"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/04/e7dd3a2dc52977d54b98542742da2aa8c2fc5356e45339f37b908ff5dfc5/pygobject_stubs-2.12.0.tar.gz", hash = "sha256:4dad2d876c070a16f604c249bb70e8cbc36373151a6731d826a8436c6a80b99d", size = 810326 }
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
In this PR, I sugggest new design of `Listener`.

## Key Difference

Before:
```
listener = Listener(callback)
listener.configure(a=1)
```

After:
```
listener = Listener().configure(a=1, callback=callback)
```