### PR TITLE
Add `owa mcap migrate rollback`, `owa mcap migrate cleanup`

### DIFF
--- a/projects/owa-cli/owa/cli/mcap/__init__.py
+++ b/projects/owa-cli/owa/cli/mcap/__init__.py
@@ -8,7 +8,7 @@ app = typer.Typer(help="MCAP file management commands.")
 
 app.command()(cat.cat)
 app.command()(convert.convert)
-app.command()(migrate.migrate)
+app.add_typer(migrate.app, name="migrate")
 app.command()(info.info)
 app.command()(sanitize.sanitize)
 

--- a/projects/owa-cli/owa/cli/mcap/migrate/__init__.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/__init__.py
@@ -1,15 +1,33 @@
+import typer
+
+from .cleanup import cleanup
 from .migrate import (
     MigrationOrchestrator,
     MigrationResult,
     ScriptMigrator,
     detect_files_needing_migration,
-    migrate,
     validate_migration_output,
     validate_verification_output,
 )
+from .migrate import (
+    migrate as migrate_command,
+)
+from .rollback import rollback
+
+# Create the migrate app with subcommands
+app = typer.Typer(help="MCAP migration commands with rollback and cleanup support.")
+
+# Add subcommands
+app.command(name="run")(migrate_command)
+app.command(name="rollback")(rollback)
+app.command(name="cleanup")(cleanup)
+
+# Expose the app as migrate for CLI registration
+migrate = app
 
 __all__ = [
     "migrate",
+    "app",
     "MigrationOrchestrator",
     "ScriptMigrator",
     "MigrationResult",

--- a/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
@@ -1,0 +1,268 @@
+"""
+MCAP backup cleanup functionality.
+
+This module provides functionality to find and clean up backup files (.mcap.backup)
+created during migration operations.
+"""
+
+import glob
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+
+from owa.cli.mcap.backup_utils import generate_backup_path
+from owa.cli.mcap.migrate.file_utils import (
+    add_cleanup_row,
+    create_file_info_table,
+    format_datetime,
+    format_file_size,
+)
+
+
+@dataclass
+class BackupFileInfo:
+    """Information about a backup file."""
+
+    backup_path: Path
+    original_path: Path
+    backup_size: Optional[int] = None
+    backup_modified: Optional[datetime] = None
+    original_exists: bool = False
+    original_size: Optional[int] = None
+    original_modified: Optional[datetime] = None
+
+
+def find_backup_files_by_pattern(patterns: List[str], console: Console) -> List[BackupFileInfo]:
+    """
+    Find backup files using glob patterns.
+
+    Args:
+        patterns: List of glob patterns to search for backup files
+        console: Rich console for output
+
+    Returns:
+        List of BackupFileInfo objects
+    """
+    backup_infos = []
+    all_backup_paths = set()
+
+    for pattern in patterns:
+        try:
+            # Expand the pattern to find backup files
+            if pattern.endswith(".backup") or ".backup" in pattern:
+                # Direct backup file pattern
+                backup_paths = [Path(p) for p in glob.glob(pattern, recursive=True)]
+            else:
+                # MCAP file pattern - find corresponding backup files
+                mcap_paths = [Path(p) for p in glob.glob(pattern, recursive=True)]
+                backup_paths = []
+                for mcap_path in mcap_paths:
+                    if mcap_path.suffix == ".mcap":
+                        backup_path = generate_backup_path(mcap_path)
+                        if backup_path.exists():
+                            backup_paths.append(backup_path)
+
+            all_backup_paths.update(backup_paths)
+
+        except Exception as e:
+            console.print(f"[yellow]Warning: Error processing pattern '{pattern}': {e}[/yellow]")
+
+    # Convert to BackupFileInfo objects
+    for backup_path in all_backup_paths:
+        if not backup_path.exists():
+            continue
+
+        # Determine original file path
+        if backup_path.name.endswith(".mcap.backup"):
+            original_path = backup_path.with_suffix("")  # Remove .backup
+        else:
+            console.print(f"[yellow]Warning: Unexpected backup file name format: {backup_path}[/yellow]")
+            continue
+
+        backup_info = BackupFileInfo(backup_path=backup_path, original_path=original_path)
+
+        # Get backup file information
+        try:
+            stat = backup_path.stat()
+            backup_info.backup_size = stat.st_size
+            backup_info.backup_modified = datetime.fromtimestamp(stat.st_mtime)
+        except Exception as e:
+            console.print(f"[yellow]Warning: Could not read backup file info for {backup_path}: {e}[/yellow]")
+
+        # Check if original file exists and get its info
+        if original_path.exists():
+            backup_info.original_exists = True
+            try:
+                stat = original_path.stat()
+                backup_info.original_size = stat.st_size
+                backup_info.original_modified = datetime.fromtimestamp(stat.st_mtime)
+            except Exception as e:
+                console.print(f"[yellow]Warning: Could not read original file info for {original_path}: {e}[/yellow]")
+
+        backup_infos.append(backup_info)
+
+    return backup_infos
+
+
+def find_all_backup_files(directories: List[Path], console: Console) -> List[BackupFileInfo]:
+    """
+    Find all backup files in the specified directories.
+
+    Args:
+        directories: List of directories to search
+        console: Rich console for output
+
+    Returns:
+        List of BackupFileInfo objects
+    """
+    patterns = []
+
+    for directory in directories:
+        if directory.is_file():
+            # Single file - check if it's a backup or find its backup
+            if directory.name.endswith(".mcap.backup"):
+                patterns.append(str(directory))
+            elif directory.suffix == ".mcap":
+                patterns.append(str(directory))
+            else:
+                console.print(f"[yellow]Skipping non-MCAP file: {directory}[/yellow]")
+        elif directory.is_dir():
+            # Directory - find all backup files recursively
+            patterns.append(str(directory / "**" / "*.mcap.backup"))
+        else:
+            console.print(f"[yellow]Path not found: {directory}[/yellow]")
+
+    return find_backup_files_by_pattern(patterns, console)
+
+
+def display_cleanup_summary(backup_infos: List[BackupFileInfo], console: Console) -> None:
+    """
+    Display a summary table of backup files to be cleaned up.
+
+    Args:
+        backup_infos: List of backup file information
+        console: Rich console for output
+    """
+    if not backup_infos:
+        console.print("[yellow]No backup files found[/yellow]")
+        return
+
+    # Create unified table
+    table = create_file_info_table("cleanup")
+    total_size = 0
+
+    for info in backup_infos:
+        # Format dates and sizes using shared utilities
+        backup_date = format_datetime(info.backup_modified)
+        original_date = format_datetime(info.original_modified)
+        backup_size_str = format_file_size(info.backup_size)
+        original_size_str = format_file_size(info.original_size)
+
+        # Track total size for summary
+        if info.backup_size is not None:
+            total_size += info.backup_size
+
+        # Determine status
+        if info.original_exists:
+            if info.original_size == info.backup_size:
+                status = "SAME SIZE"
+            else:
+                status = "DIFFERENT"
+        else:
+            status = "ORPHANED"
+
+        # Add row using unified function
+        add_cleanup_row(table, info, backup_date, backup_size_str, original_date, original_size_str, status)
+
+    console.print("\n[bold]Cleanup Summary[/bold]")
+    console.print(table)
+
+    # Show total size
+    if total_size > 0:
+        total_str = format_file_size(total_size)
+        console.print(f"\n[bold]Total backup size: {total_str}[/bold]")
+
+
+def cleanup(
+    patterns: Optional[List[str]] = typer.Argument(
+        None,
+        help="Patterns to search for backup files (default: all .mcap.backup files in current directory and subdirectories)",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be deleted without actually deleting"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed cleanup information"),
+) -> None:
+    """
+    Clean up MCAP backup files.
+
+    This command finds backup files (.mcap.backup) using the specified patterns
+    and removes them after confirmation. Use --dry-run to preview what would be deleted.
+
+    Examples:
+        owl mcap migrate cleanup                    # Clean all backup files in current directory tree
+        owl mcap migrate cleanup "*.mcap.backup"   # Clean backup files in current directory only
+        owl mcap migrate cleanup /path/to/backups  # Clean backup files in specific directory
+        owl mcap migrate cleanup file.mcap         # Clean backup for specific MCAP file
+    """
+    console = Console()
+
+    # Set default patterns if none provided
+    if patterns is None:
+        patterns = ["**/*.mcap.backup"]
+
+    console.print("[bold blue]MCAP Backup Cleanup Tool[/bold blue]")
+
+    if dry_run:
+        console.print("[yellow]DRY RUN MODE - No files will be deleted[/yellow]")
+
+    # Find backup files
+    backup_infos = find_backup_files_by_pattern(patterns, console)
+
+    if not backup_infos:
+        console.print("[yellow]No backup files found matching the specified patterns[/yellow]")
+        return
+
+    # Display summary
+    display_cleanup_summary(backup_infos, console)
+
+    if dry_run:
+        console.print(f"\n[yellow]Would delete {len(backup_infos)} backup files[/yellow]")
+        return
+
+    # Confirm cleanup
+    if not yes and not typer.confirm(f"\nProceed with deleting {len(backup_infos)} backup files?", default=False):
+        console.print("Cleanup cancelled.")
+        return
+
+    # Perform cleanup
+    console.print(f"\n[bold]Starting cleanup of {len(backup_infos)} backup files...[/bold]")
+
+    successful_deletions = 0
+    failed_deletions = 0
+
+    for i, info in enumerate(backup_infos, 1):
+        if verbose:
+            console.print(f"\n[bold cyan]File {i}/{len(backup_infos)}: {info.backup_path}[/bold cyan]")
+
+        try:
+            info.backup_path.unlink()
+            successful_deletions += 1
+
+            if verbose:
+                console.print(f"[green]Deleted: {info.backup_path}[/green]")
+
+        except Exception as e:
+            console.print(f"[red]Failed to delete {info.backup_path}: {e}[/red]")
+            failed_deletions += 1
+
+    # Final summary
+    console.print("\n[bold]Cleanup Complete[/bold]")
+    console.print(f"[green]Deleted: {successful_deletions}[/green]")
+    console.print(f"[red]Failed: {failed_deletions}[/red]")
+
+    if failed_deletions > 0:
+        raise typer.Exit(1)

--- a/projects/owa-cli/owa/cli/mcap/migrate/file_utils.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/file_utils.py
@@ -1,0 +1,187 @@
+"""
+Shared utilities for MCAP file operations.
+
+This module provides common functionality used across migrate, rollback, and cleanup commands
+to avoid code duplication and ensure consistency.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from rich.table import Table
+
+from mcap_owa.highlevel import OWAMcapReader
+
+
+def format_file_size(size_bytes: Optional[int]) -> str:
+    """
+    Format file size in human-readable format.
+
+    Args:
+        size_bytes: Size in bytes, or None if unknown
+
+    Returns:
+        Formatted size string (e.g., "1.5 KB", "2.3 MB", "Unknown")
+    """
+    if size_bytes is None:
+        return "Unknown"
+
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    else:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def format_datetime(dt: Optional[datetime]) -> str:
+    """
+    Format datetime in consistent format.
+
+    Args:
+        dt: Datetime object, or None if unknown
+
+    Returns:
+        Formatted datetime string (e.g., "2025-06-25 20:30:15", "Unknown")
+    """
+    if dt is None:
+        return "Unknown"
+
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def detect_mcap_version(file_path: Path) -> str:
+    """
+    Safely detect the version of an MCAP file.
+
+    Args:
+        file_path: Path to the MCAP file
+
+    Returns:
+        Version string or "unknown" if detection fails
+    """
+    try:
+        with OWAMcapReader(file_path) as reader:
+            file_version = reader.file_version
+            return file_version if file_version and file_version != "unknown" else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def get_file_info(file_path: Path) -> tuple[Optional[int], Optional[datetime], str]:
+    """
+    Get comprehensive file information.
+
+    Args:
+        file_path: Path to the file
+
+    Returns:
+        Tuple of (size_bytes, modified_datetime, version)
+        Any value can be None/"unknown" if detection fails
+    """
+    size = None
+    modified = None
+    version = "unknown"
+
+    try:
+        if file_path.exists():
+            stat = file_path.stat()
+            size = stat.st_size
+            modified = datetime.fromtimestamp(stat.st_mtime)
+
+            # Only try version detection for MCAP files
+            if file_path.suffix == ".mcap":
+                version = detect_mcap_version(file_path)
+    except Exception:
+        pass
+
+    return size, modified, version
+
+
+def create_file_info_table(table_type: str = "rollback") -> Table:
+    """
+    Create a standardized table for displaying file information.
+
+    Args:
+        table_type: Type of table ("rollback" or "cleanup")
+
+    Returns:
+        Configured Rich Table object
+    """
+    table = Table(show_header=True, header_style="bold magenta")
+
+    if table_type == "rollback":
+        # Rollback table: focus on original file with backup info
+        table.add_column("Original File", style="cyan")
+        table.add_column("Original Date", style="dim")
+        table.add_column("Original Size", justify="right", style="dim")
+        table.add_column("Backup Date", style="yellow")
+        table.add_column("Backup Size", justify="right")
+        table.add_column("Original Version", style="green")
+        table.add_column("Backup Version", style="blue")
+        table.add_column("Status", justify="center")
+    else:  # cleanup
+        # Cleanup table: focus on backup file with original info
+        table.add_column("Backup File", style="cyan")
+        table.add_column("Backup Date", style="yellow")
+        table.add_column("Backup Size", justify="right")
+        table.add_column("Original File", style="green")
+        table.add_column("Original Date", style="dim")
+        table.add_column("Original Size", justify="right", style="dim")
+        table.add_column("Status", justify="center")
+
+    return table
+
+
+def add_rollback_row(
+    table: Table, info, original_date: str, original_size_str: str, backup_date: str, backup_size_str: str, status: str
+) -> None:
+    """
+    Add a row to a rollback table with standardized formatting.
+
+    Args:
+        table: Rich Table object
+        info: BackupInfo object
+        original_date: Formatted original date string
+        original_size_str: Formatted original size string
+        backup_date: Formatted backup date string
+        backup_size_str: Formatted backup size string
+        status: Status string
+    """
+    table.add_row(
+        str(info.original_path.name),
+        original_date,
+        original_size_str,
+        backup_date,
+        backup_size_str,
+        info.original_version or "Unknown",
+        info.backup_version or "Unknown",
+        status,
+    )
+
+
+def add_cleanup_row(
+    table: Table, info, backup_date: str, backup_size_str: str, original_date: str, original_size_str: str, status: str
+) -> None:
+    """
+    Add a row to a cleanup table with standardized formatting.
+
+    Args:
+        table: Rich Table object
+        info: BackupFileInfo object
+        backup_date: Formatted backup date string
+        backup_size_str: Formatted backup size string
+        original_date: Formatted original date string
+        original_size_str: Formatted original size string
+        status: Status string
+    """
+    table.add_row(
+        str(info.backup_path.name),
+        backup_date,
+        backup_size_str,
+        str(info.original_path.name),
+        original_date,
+        original_size_str,
+        status,
+    )

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrators/README.md
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrators/README.md
@@ -255,7 +255,7 @@ Migrators **SHOULD** be tested with:
 
 ## Testing Tips
 
-You can test your migrator works within virtual environment without uploading package to pypi:
+You can test your migrator works within virtual environment without uploading package to pypi, by adding editable source:
 
 ```
 # dependencies = [

--- a/projects/owa-cli/owa/cli/mcap/migrate/rollback.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/rollback.py
@@ -1,0 +1,213 @@
+"""
+MCAP migration rollback functionality.
+
+This module provides functionality to rollback MCAP files from their backup files,
+typically used when a migration fails or needs to be undone.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+
+from owa.cli.mcap.backup_utils import generate_backup_path, rollback_from_backup
+from owa.cli.mcap.migrate.file_utils import (
+    add_rollback_row,
+    create_file_info_table,
+    detect_mcap_version,
+    format_datetime,
+    format_file_size,
+)
+
+
+@dataclass
+class BackupInfo:
+    """Information about a backup file and its corresponding original file."""
+
+    original_path: Path
+    backup_path: Path
+    backup_exists: bool
+    original_exists: bool
+    backup_size: Optional[int] = None
+    backup_modified: Optional[datetime] = None
+    original_size: Optional[int] = None
+    original_modified: Optional[datetime] = None
+    original_version: Optional[str] = None
+    backup_version: Optional[str] = None
+
+
+def find_backup_files(file_paths: List[Path], console: Console) -> List[BackupInfo]:
+    """
+    Find backup files corresponding to the given MCAP files.
+
+    Args:
+        file_paths: List of original MCAP file paths
+        console: Rich console for output
+
+    Returns:
+        List of BackupInfo objects with backup information
+    """
+    backup_infos = []
+
+    for file_path in file_paths:
+        if not file_path.suffix == ".mcap":
+            console.print(f"[yellow]Skipping non-MCAP file: {file_path}[/yellow]")
+            continue
+
+        backup_path = generate_backup_path(file_path)
+        backup_exists = backup_path.exists()
+        original_exists = file_path.exists()
+
+        backup_info = BackupInfo(
+            original_path=file_path,
+            backup_path=backup_path,
+            backup_exists=backup_exists,
+            original_exists=original_exists,
+        )
+
+        # Get backup file information if it exists
+        if backup_exists:
+            try:
+                stat = backup_path.stat()
+                backup_info.backup_size = stat.st_size
+                backup_info.backup_modified = datetime.fromtimestamp(stat.st_mtime)
+                backup_info.backup_version = detect_mcap_version(backup_path)
+            except Exception as e:
+                console.print(f"[yellow]Warning: Could not read backup info for {backup_path}: {e}[/yellow]")
+
+        # Get original file information if it exists
+        if original_exists:
+            try:
+                stat = file_path.stat()
+                backup_info.original_size = stat.st_size
+                backup_info.original_modified = datetime.fromtimestamp(stat.st_mtime)
+                backup_info.original_version = detect_mcap_version(file_path)
+            except Exception as e:
+                console.print(f"[yellow]Warning: Could not read original file info for {file_path}: {e}[/yellow]")
+
+        backup_infos.append(backup_info)
+
+    return backup_infos
+
+
+def display_rollback_summary(backup_infos: List[BackupInfo], console: Console) -> List[BackupInfo]:
+    """
+    Display a summary table of files that can be rolled back.
+
+    Args:
+        backup_infos: List of backup information
+        console: Rich console for output
+
+    Returns:
+        List of BackupInfo objects that can be rolled back
+    """
+    # Filter for files that can actually be rolled back
+    rollbackable = [info for info in backup_infos if info.backup_exists]
+
+    if not rollbackable:
+        console.print("[yellow]No backup files found for rollback[/yellow]")
+        return []
+
+    # Create unified table
+    table = create_file_info_table("rollback")
+
+    for info in rollbackable:
+        # Format dates and sizes using shared utilities
+        backup_date = format_datetime(info.backup_modified)
+        original_date = format_datetime(info.original_modified)
+        original_size_str = format_file_size(info.original_size)
+        backup_size_str = format_file_size(info.backup_size)
+
+        # Determine status
+        if not info.original_exists:
+            status = "MISSING"
+        elif info.original_version == info.backup_version:
+            status = "SAME"
+        else:
+            status = "READY"
+
+        # Add row using unified function
+        add_rollback_row(table, info, original_date, original_size_str, backup_date, backup_size_str, status)
+
+    console.print("\n[bold]Rollback Summary[/bold]")
+    console.print(table)
+
+    return rollbackable
+
+
+def rollback(
+    files: List[Path] = typer.Argument(..., help="MCAP files to rollback from backup"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed rollback information"),
+) -> None:
+    """
+    Rollback MCAP files from their backup files.
+
+    This command finds backup files (.mcap.backup) corresponding to the specified
+    MCAP files and restores the original files from the backups. The backup files
+    are removed after successful rollback.
+    """
+    console = Console()
+
+    console.print("[bold blue]MCAP Rollback Tool[/bold blue]")
+    console.print(f"Files to check: {len(files)}")
+
+    # Find backup files
+    backup_infos = find_backup_files(files, console)
+
+    if not backup_infos:
+        console.print("[yellow]No files to process[/yellow]")
+        return
+
+    # Display summary and get rollbackable files
+    rollbackable = display_rollback_summary(backup_infos, console)
+
+    if not rollbackable:
+        return
+
+    # Show warnings for problematic cases
+    for info in rollbackable:
+        if not info.original_exists:
+            console.print(f"[yellow]Warning: Original file missing, will restore: {info.original_path}[/yellow]")
+        elif info.original_version == info.backup_version:
+            console.print(f"[yellow]Warning: Original and backup have same version: {info.original_path}[/yellow]")
+
+    # Confirm rollback
+    if not yes and not typer.confirm(f"\nProceed with rolling back {len(rollbackable)} files?", default=False):
+        console.print("Rollback cancelled.")
+        return
+
+    # Perform rollbacks
+    console.print(f"\n[bold]Starting rollback of {len(rollbackable)} files...[/bold]")
+
+    successful_rollbacks = 0
+    failed_rollbacks = 0
+
+    for i, info in enumerate(rollbackable, 1):
+        console.print(f"\n[bold cyan]File {i}/{len(rollbackable)}: {info.original_path}[/bold cyan]")
+
+        if verbose:
+            console.print(f"Restoring from: {info.backup_path}")
+
+        try:
+            success = rollback_from_backup(info.original_path, info.backup_path, console, delete_backup=True)
+
+            if success:
+                successful_rollbacks += 1
+            else:
+                failed_rollbacks += 1
+
+        except Exception as e:
+            console.print(f"[red]Unexpected error during rollback: {e}[/red]")
+            failed_rollbacks += 1
+
+    # Final summary
+    console.print("\n[bold]Rollback Complete[/bold]")
+    console.print(f"[green]Successful: {successful_rollbacks}[/green]")
+    console.print(f"[red]Failed: {failed_rollbacks}[/red]")
+
+    if failed_rollbacks > 0:
+        raise typer.Exit(1)

--- a/projects/owa-cli/tests/mcap/migrate/test_core.py
+++ b/projects/owa-cli/tests/mcap/migrate/test_core.py
@@ -34,7 +34,7 @@ class TestMigrateIntegration:
         mock_file_detection.return_value = [mock_info]
 
         # Run migrate command
-        result = cli_runner.invoke(mcap_app, ["migrate", str(test_file), "--yes"])
+        result = cli_runner.invoke(mcap_app, ["migrate", "run", str(test_file), "--yes"])
 
         assert result.exit_code == 0
         mock_migration_orchestrator.migrate_file.assert_called_once()
@@ -57,7 +57,7 @@ class TestMigrateIntegration:
         mock_file_detection.return_value = [mock_info]
 
         # Run migrate command
-        result = cli_runner.invoke(mcap_app, ["migrate", str(test_file), "--yes"])
+        result = cli_runner.invoke(mcap_app, ["migrate", "run", str(test_file), "--yes"])
 
         assert result.exit_code == 1
         mock_migration_orchestrator.migrate_file.assert_called_once()
@@ -96,7 +96,7 @@ class TestMigrateIntegration:
                 mock_detect.return_value = [mock_info1, mock_info2]
 
                 # Run migrate on multiple files
-                result = cli_runner.invoke(mcap_app, ["migrate", str(test_file1), str(test_file2), "--yes"])
+                result = cli_runner.invoke(mcap_app, ["migrate", "run", str(test_file1), str(test_file2), "--yes"])
 
                 assert result.exit_code == 0
                 # Should be called twice, once for each file
@@ -123,7 +123,7 @@ class TestMigrateIntegration:
                 mock_detect.return_value = [mock_info]
 
                 # Run migrate in dry-run mode
-                result = cli_runner.invoke(mcap_app, ["migrate", str(test_file), "--dry-run"])
+                result = cli_runner.invoke(mcap_app, ["migrate", "run", str(test_file), "--dry-run"])
 
                 assert result.exit_code == 0
                 # Original file should be unchanged
@@ -140,7 +140,7 @@ class TestMigrateIntegration:
             mock_detect.return_value = []  # No files need migration
 
             # Run migrate command
-            result = cli_runner.invoke(mcap_app, ["migrate", str(test_file), "--yes"])
+            result = cli_runner.invoke(mcap_app, ["migrate", "run", str(test_file), "--yes"])
 
             assert result.exit_code == 0
             assert "No files found matching the pattern" in result.output


### PR DESCRIPTION
This pull request introduces significant enhancements to the MCAP migration CLI, including the addition of subcommands for rollback and cleanup, shared utilities for file operations, and expanded test coverage. These changes improve modularity, functionality, and reliability of the CLI.

### CLI Enhancements:
* Updated `migrate` command registration in `projects/owa-cli/owa/cli/mcap/__init__.py` to use `typer.Typer`, enabling subcommands like `run`, `rollback`, and `cleanup`.
* Introduced a new `cleanup` subcommand in `projects/owa-cli/owa/cli/mcap/migrate/cleanup.py` for cleaning up `.mcap.backup` files with features like dry-run mode, confirmation prompts, and detailed summaries.
* Added a `rollback` subcommand in `projects/owa-cli/owa/cli/mcap/migrate/rollback.py` to restore MCAP files from backups, supporting scenarios where migrations need to be undone.

### Shared Utilities:
* Created `projects/owa-cli/owa/cli/mcap/migrate/file_utils.py` to provide shared functionality for file operations, such as formatting file sizes and dates, detecting MCAP versions, and creating standardized tables for rollback and cleanup summaries.

### Test Coverage:
* Expanded test suite in `projects/owa-cli/tests/mcap/migrate/test_cli.py` to validate the new subcommands (`run`, `rollback`, and `cleanup`) and their help output, ensuring robust CLI behavior.

### Documentation Update:
* Updated `README.md` in `projects/owa-cli/owa/cli/mcap/migrate/migrators` to clarify testing instructions for migrators within a virtual environment.