### PR TITLE
Consistent output across `owl mcap migrate` commands

### DIFF
--- a/projects/owa-cli/owa/cli/mcap/migrate/file_utils.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/file_utils.py
@@ -111,31 +111,28 @@ def create_file_info_table(table_type: str = "rollback") -> Table:
     """
     table = Table(show_header=True, header_style="bold magenta")
 
+    # Both tables use consistent column order: Current info first, then Backup info, then Status
     if table_type == "rollback":
-        # Rollback table: focus on original file with backup info
-        table.add_column("Original File", style="cyan")
-        table.add_column("Original Date", style="dim")
-        table.add_column("Original Size", justify="right", style="dim")
-        table.add_column("Backup Date", style="yellow")
-        table.add_column("Backup Size", justify="right")
-        table.add_column("Original Version", style="green")
-        table.add_column("Backup Version", style="blue")
-        table.add_column("Status", justify="center")
+        # Rollback table: focus on current file that will be replaced
+        table.add_column("Current File", style="cyan")
     else:  # cleanup
-        # Cleanup table: focus on backup file with original info
+        # Cleanup table: focus on backup file that will be deleted
         table.add_column("Backup File", style="cyan")
-        table.add_column("Backup Date", style="yellow")
-        table.add_column("Backup Size", justify="right")
-        table.add_column("Original File", style="green")
-        table.add_column("Original Date", style="dim")
-        table.add_column("Original Size", justify="right", style="dim")
-        table.add_column("Status", justify="center")
+
+    # Consistent column order for both tables
+    table.add_column("Current Date", style="dim")
+    table.add_column("Current Size", justify="right", style="dim")
+    table.add_column("Current Version", style="green")
+    table.add_column("Backup Date", style="yellow")
+    table.add_column("Backup Size", justify="right")
+    table.add_column("Backup Version", style="blue")
+    table.add_column("Status", justify="center")
 
     return table
 
 
 def add_rollback_row(
-    table: Table, info, original_date: str, original_size_str: str, backup_date: str, backup_size_str: str, status: str
+    table: Table, info, current_date: str, current_size_str: str, backup_date: str, backup_size_str: str, status: str
 ) -> None:
     """
     Add a row to a rollback table with standardized formatting.
@@ -143,26 +140,34 @@ def add_rollback_row(
     Args:
         table: Rich Table object
         info: BackupInfo object
-        original_date: Formatted original date string
-        original_size_str: Formatted original size string
+        current_date: Formatted current date string
+        current_size_str: Formatted current size string
         backup_date: Formatted backup date string
         backup_size_str: Formatted backup size string
         status: Status string
     """
     table.add_row(
-        str(info.original_path.name),
-        original_date,
-        original_size_str,
-        backup_date,
-        backup_size_str,
-        info.original_version or "Unknown",
-        info.backup_version or "Unknown",
-        status,
+        str(info.original_path.name),  # Current File
+        current_date,  # Current Date
+        current_size_str,  # Current Size
+        info.original_version or "Unknown",  # Current Version
+        backup_date,  # Backup Date
+        backup_size_str,  # Backup Size
+        info.backup_version or "Unknown",  # Backup Version
+        status,  # Status
     )
 
 
 def add_cleanup_row(
-    table: Table, info, backup_date: str, backup_size_str: str, original_date: str, original_size_str: str, status: str
+    table: Table,
+    info,
+    current_date: str,
+    current_size_str: str,
+    backup_date: str,
+    backup_size_str: str,
+    current_version: str,
+    backup_version: str,
+    status: str,
 ) -> None:
     """
     Add a row to a cleanup table with standardized formatting.
@@ -170,18 +175,21 @@ def add_cleanup_row(
     Args:
         table: Rich Table object
         info: BackupFileInfo object
+        current_date: Formatted current date string
+        current_size_str: Formatted current size string
         backup_date: Formatted backup date string
         backup_size_str: Formatted backup size string
-        original_date: Formatted original date string
-        original_size_str: Formatted original size string
+        current_version: Current file version
+        backup_version: Backup file version
         status: Status string
     """
     table.add_row(
-        str(info.backup_path.name),
-        backup_date,
-        backup_size_str,
-        str(info.original_path.name),
-        original_date,
-        original_size_str,
-        status,
+        str(info.backup_path.name),  # Backup File
+        current_date,  # Current Date
+        current_size_str,  # Current Size
+        current_version,  # Current Version
+        backup_date,  # Backup Date
+        backup_size_str,  # Backup Size
+        backup_version,  # Backup Version
+        status,  # Status
     )

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrate.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrate.py
@@ -567,7 +567,7 @@ def migrate(
         console.print(f"\n[yellow]Would migrate {len(files_needing_migration)} files[/yellow]")
         return
 
-    if not yes and not typer.confirm(f"\nProceed with migrating {len(files_needing_migration)} files?", default=True):
+    if not yes and not typer.confirm(f"\nProceed with migrating {len(files_needing_migration)} files?"):
         console.print("Migration cancelled.")
         return
 

--- a/projects/owa-cli/owa/cli/mcap/migrate/rollback.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/rollback.py
@@ -117,8 +117,8 @@ def display_rollback_summary(backup_infos: List[BackupInfo], console: Console) -
     for info in rollbackable:
         # Format dates and sizes using shared utilities
         backup_date = format_datetime(info.backup_modified)
-        original_date = format_datetime(info.original_modified)
-        original_size_str = format_file_size(info.original_size)
+        current_date = format_datetime(info.original_modified)
+        current_size_str = format_file_size(info.original_size)
         backup_size_str = format_file_size(info.backup_size)
 
         # Determine status
@@ -130,7 +130,7 @@ def display_rollback_summary(backup_infos: List[BackupInfo], console: Console) -
             status = "READY"
 
         # Add row using unified function
-        add_rollback_row(table, info, original_date, original_size_str, backup_date, backup_size_str, status)
+        add_rollback_row(table, info, current_date, current_size_str, backup_date, backup_size_str, status)
 
     console.print("\n[bold]Rollback Summary[/bold]")
     console.print(table)
@@ -171,9 +171,9 @@ def rollback(
     # Show warnings for problematic cases
     for info in rollbackable:
         if not info.original_exists:
-            console.print(f"[yellow]Warning: Original file missing, will restore: {info.original_path}[/yellow]")
+            console.print(f"[yellow]Warning: Current file missing, will restore: {info.original_path}[/yellow]")
         elif info.original_version == info.backup_version:
-            console.print(f"[yellow]Warning: Original and backup have same version: {info.original_path}[/yellow]")
+            console.print(f"[yellow]Warning: Current and backup have same version: {info.original_path}[/yellow]")
 
     # Confirm rollback
     if not yes and not typer.confirm(f"\nProceed with rolling back {len(rollbackable)} files?", default=False):

--- a/projects/owa-cli/tests/mcap/migrate/test_cli.py
+++ b/projects/owa-cli/tests/mcap/migrate/test_cli.py
@@ -340,8 +340,9 @@ def test_migrate_rollback_no_backups(cli_runner, temp_dir):
 
 
 def test_migrate_cleanup_no_backups(cli_runner, temp_dir):
-    """Test cleanup with no backup files."""
-    result = cli_runner.invoke(app, ["mcap", "migrate", "cleanup", "--dry-run"])
+    """Test cleanup with no backup files in a controlled directory."""
+    # Run cleanup in the temp_dir to confine the operation to a safe directory
+    result = cli_runner.invoke(app, ["mcap", "migrate", "cleanup", str(temp_dir / "*.mcap.backup"), "--dry-run"])
     assert result.exit_code == 0
     assert "No backup files found" in result.stdout
 
@@ -385,8 +386,8 @@ def test_migrate_rollback_cleanup_workflow(
     assert not backup_file.exists(), "Backup file should be removed after cleanup"
 
 
-def test_migrate_rollback_with_missing_original(cli_runner, temp_dir):
-    """Test rollback when original file is missing (restore scenario)."""
+def test_migrate_rollback_with_missing_current(cli_runner, temp_dir):
+    """Test rollback when current file is missing (restore scenario)."""
     # Create backup file without original
     backup_file = temp_dir / "missing.mcap.backup"
     backup_file.write_text("backup content")
@@ -419,7 +420,7 @@ def test_migrate_cleanup_with_patterns(cli_runner, temp_dir):
     # Test cleanup with specific pattern
     result = cli_runner.invoke(app, ["mcap", "migrate", "cleanup", str(temp_dir / "test1.mcap.backup"), "--dry-run"])
     assert result.exit_code == 0
-    assert "test1.m" in result.stdout  # Filename may be truncated in table
+    assert "test1" in result.stdout  # Filename should appear in table (may be truncated)
     assert "Would delete 1 backup files" in result.stdout
 
     # Test cleanup with wildcard pattern


### PR DESCRIPTION
This pull request introduces enhancements to the `mcap` migration utilities in the `owa-cli` project, focusing on improving file version tracking, standardizing table formats, and refining test cases. The most important changes include adding version detection for both backup and current files, updating table column structures for consistency, and refining test cases to align with the updated functionality.

### Enhancements to file version tracking:
* Added `detect_mcap_version` utility to extract version information for backup and current files. This is now used in `find_backup_files_by_pattern` to populate `backup_version` and `original_version` attributes in `BackupFileInfo`. (`projects/owa-cli/owa/cli/mcap/migrate/cleanup.py`, [[1]](diffhunk://#diff-1a2918c281febecf0c369dad74ceb1e524675ba003e5d5e3403a297538b3fb7eR21) [[2]](diffhunk://#diff-1a2918c281febecf0c369dad74ceb1e524675ba003e5d5e3403a297538b3fb7eR96) [[3]](diffhunk://#diff-1a2918c281febecf0c369dad74ceb1e524675ba003e5d5e3403a297538b3fb7eR107)
* Updated the `display_cleanup_summary` function to include file version information in the cleanup summary. (`projects/owa-cli/owa/cli/mcap/migrate/cleanup.py`, [[1]](diffhunk://#diff-1a2918c281febecf0c369dad74ceb1e524675ba003e5d5e3403a297538b3fb7eL161-R170) [[2]](diffhunk://#diff-1a2918c281febecf0c369dad74ceb1e524675ba003e5d5e3403a297538b3fb7eL179-R196)

### Standardization of table formats:
* Refactored `create_file_info_table` to ensure consistent column order across rollback and cleanup tables. Columns now display current file information first, followed by backup file information and status. (`projects/owa-cli/owa/cli/mcap/migrate/file_utils.py`, [projects/owa-cli/owa/cli/mcap/migrate/file_utils.pyR114-R194](diffhunk://#diff-0ad0080f9044918e83c4631b29561877f0b13d0ec040e78b2b96aa4e2852cad7R114-R194))
* Updated `add_rollback_row` and `add_cleanup_row` functions to align with the new column structure. (`projects/owa-cli/owa/cli/mcap/migrate/file_utils.py`, [projects/owa-cli/owa/cli/mcap/migrate/file_utils.pyR114-R194](diffhunk://#diff-0ad0080f9044918e83c4631b29561877f0b13d0ec040e78b2b96aa4e2852cad7R114-R194))

### Refinements to test cases:
* Improved the `test_migrate_cleanup_no_backups` test to use a controlled directory and specific patterns for cleanup operations. (`projects/owa-cli/tests/mcap/migrate/test_cli.py`, [projects/owa-cli/tests/mcap/migrate/test_cli.pyL343-R345](diffhunk://#diff-4705686dfab46b6c6a6423fab44d5a089f0d290bed7337bab0d68c6859ce4418L343-R345))
* Renamed and adjusted test cases to reflect terminology changes (e.g., "original" to "current") and ensure alignment with updated functionality. (`projects/owa-cli/tests/mcap/migrate/test_cli.py`, [[1]](diffhunk://#diff-4705686dfab46b6c6a6423fab44d5a089f0d290bed7337bab0d68c6859ce4418L388-R390) [[2]](diffhunk://#diff-4705686dfab46b6c6a6423fab44d5a089f0d290bed7337bab0d68c6859ce4418L422-R423)