### PR TITLE
Remove useless field in migrate result schema, now prints verification error message

### DIFF
--- a/projects/owa-cli/owa/cli/mcap/migrate/schemas.json
+++ b/projects/owa-cli/owa/cli/mcap/migrate/schemas.json
@@ -36,13 +36,6 @@
         "message": {
           "type": "string",
           "description": "Success or informational message"
-        },
-        "schema_conversions": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Mapping of old schema names to new schema names"
         }
       },
       "allOf": [
@@ -148,10 +141,7 @@
         "changes_made": 5,
         "from_version": "0.2.0",
         "to_version": "0.3.0",
-        "schema_conversions": {
-          "owa_env_desktop.KeyboardEvent": "owa.env.desktop.KeyboardEvent",
-          "owa_env_desktop.MouseEvent": "owa.env.desktop.MouseEvent"
-        }
+        "message": "Migration completed successfully"
       }
     },
     {

--- a/projects/owa-cli/tests/mcap/migrate/test_core.py
+++ b/projects/owa-cli/tests/mcap/migrate/test_core.py
@@ -165,7 +165,9 @@ class TestMigrationOrchestrator:
             mock_migrator.from_version = "0.3.0"
             mock_migrator.to_version = "0.4.0"
             mock_migrator.migrate.return_value = MagicMock(success=True, changes_made=1)
-            mock_migrator.verify_migration.return_value = True
+            from owa.cli.mcap.migrate.migrate import VerificationResult
+
+            mock_migrator.verify_migration.return_value = VerificationResult(success=True)
 
             with patch.object(orchestrator, "get_migration_path") as mock_get_path:
                 mock_get_path.return_value = [mock_migrator]


### PR DESCRIPTION
This pull request refactors the migration and verification logic in the `owa-cli` project to improve clarity, consistency, and adherence to JSON schema standards. It introduces new data classes for structured results, updates method signatures, and adjusts test cases to align with these changes.

### Refactoring for structured results:

* [`projects/owa-cli/owa/cli/mcap/migrate/migrate.py`](diffhunk://#diff-63718d3e4faa4c12e6405b57587e57fab7b9682c6cbd024bc86616861bc3489eL35-R52): Introduced the `VerificationResult` data class alongside updates to the `MigrationResult` class to better match JSON schema standards. The `MigrationResult` now includes `message` and replaces `error_message` with `error`. Similarly, `VerificationResult` encapsulates verification-specific fields like `found_old_schemas`. [[1]](diffhunk://#diff-63718d3e4faa4c12e6405b57587e57fab7b9682c6cbd024bc86616861bc3489eL35-R52) [[2]](diffhunk://#diff-63718d3e4faa4c12e6405b57587e57fab7b9682c6cbd024bc86616861bc3489eL157-R176) [[3]](diffhunk://#diff-63718d3e4faa4c12e6405b57587e57fab7b9682c6cbd024bc86616861bc3489eL166-R204) [[4]](diffhunk://#diff-63718d3e4faa4c12e6405b57587e57fab7b9682c6cbd024bc86616861bc3489eL188-R229)

### Schema and output updates:

* [`projects/owa-cli/owa/cli/mcap/migrate/schemas.json`](diffhunk://#diff-74a5764e0d0fe7b54c6a75273c288a1af6251c21eafea2267e3766abd3f38237L39-L45): Removed the `schema_conversions` field from the JSON schema and added a `message` field for success or informational messages. Updated example outputs to reflect these changes. [[1]](diffhunk://#diff-74a5764e0d0fe7b54c6a75273c288a1af6251c21eafea2267e3766abd3f38237L39-L45) [[2]](diffhunk://#diff-74a5764e0d0fe7b54c6a75273c288a1af6251c21eafea2267e3766abd3f38237L151-R144)

### Test adjustments:

* `projects/owa-cli/tests/mcap/migrate/test_core.py` and `projects/owa-cli/tests/mcap/migrate/test_system.py`: Updated test cases to use the new `VerificationResult` data class and replaced references to `version_from` and `version_to` with `from_version` and `to_version`. Adjusted assertions to align with the updated result structure. [[1]](diffhunk://#diff-6de8df2d8cf730d707acfb3078aca6fafd29b5bc658247a52b377c0d76c4dd66L168-R170) [[2]](diffhunk://#diff-60e6754a48fb0dab6265286cfd63ab55e6c8d9685ee77ce0647023778a30f0d1L278-R295) [[3]](diffhunk://#diff-60e6754a48fb0dab6265286cfd63ab55e6c8d9685ee77ce0647023778a30f0d1L341-R344) [[4]](diffhunk://#diff-60e6754a48fb0dab6265286cfd63ab55e6c8d9685ee77ce0647023778a30f0d1L402-R405) [[5]](diffhunk://#diff-60e6754a48fb0dab6265286cfd63ab55e6c8d9685ee77ce0647023778a30f0d1L421-R425)

These changes improve code readability, ensure consistency with JSON schema standards, and enhance error handling and test coverage.