### PR TITLE
Improved/disabled logging for owa-core, owa-cli

### DIFF
--- a/projects/ocap/owa/ocap/record.py
+++ b/projects/ocap/owa/ocap/record.py
@@ -163,7 +163,7 @@ def record(
     record_video: Annotated[bool, typer.Option(help="Whether to record video")] = True,
     record_timestamp: Annotated[bool, typer.Option(help="Whether to record timestamp")] = True,
     show_cursor: Annotated[bool, typer.Option(help="Whether to show the cursor in the capture")] = True,
-    fps: Annotated[Optional[float], typer.Option(help="The frame rate of the video. Default is 60 fps.")] = 60.0,
+    fps: Annotated[float, typer.Option(help="The frame rate of the video. Default is 60 fps.")] = 60.0,
     window_name: Annotated[
         Optional[str], typer.Option(help="The name of the window to capture, substring of window name is supported")
     ] = None,

--- a/projects/ocap/owa/ocap/record.py
+++ b/projects/ocap/owa/ocap/record.py
@@ -237,7 +237,7 @@ def record(
 def main():
     # Check for updates on startup (skip in CI environments)
     if not os.getenv("GITHUB_ACTIONS"):
-        check_for_update("ocap")
+        check_for_update("ocap", silent=False)
     typer.run(record)
 
 

--- a/projects/owa-cli/owa/cli/__init__.py
+++ b/projects/owa-cli/owa/cli/__init__.py
@@ -12,28 +12,41 @@ import shutil
 # TODO?: replace to https://github.com/BrianPugh/cyclopts
 import typer
 from loguru import logger
+from rich.console import Console
 
 from . import env, mcap, messages, video
 from .utils import check_for_update
 
-# TODO: disable logger as library
+# Disable logger by default for library usage (following loguru best practices)
+logger.disable("owa.cli")
+
+# Console for user-facing messages
+console = Console()
+
+# Store warnings to show later
+_dependency_warnings = []
 
 
-def create_app() -> typer.Typer:
+def create_app(**kwargs) -> typer.Typer:
     """
     Create and configure the main CLI application.
+
+    Args:
+        **kwargs: Additional arguments passed to typer.Typer
 
     Returns:
         Configured Typer application
     """
-    app = typer.Typer(name="owl", help="owl - Open World agents cLi - Tools for managing OWA data and environments")
+    app = typer.Typer(
+        name="owl", help="owl - Open World agents cLi - Tools for managing OWA data and environments", **kwargs
+    )
 
     # Add core commands
     app.add_typer(mcap.app, name="mcap", help="MCAP file management commands")
     app.add_typer(env.app, name="env", help="Environment plugin management commands")
     app.add_typer(messages.app, name="messages", help="Message registry management commands")
 
-    # Add optional commands based on available dependencies
+    # Add optional commands
     _add_optional_commands(app)
 
     return app
@@ -46,7 +59,7 @@ def _add_optional_commands(app: typer.Typer) -> None:
     if _check_ffmpeg_available():
         app.add_typer(video.app, name="video", help="Video processing commands")
     else:
-        logger.warning("FFmpeg not found. Video processing commands disabled.")
+        _dependency_warnings.append("[yellow]⚠ FFmpeg not found. Video processing commands disabled.[/yellow]")
 
     # Window management commands (Windows only, requires owa.env.desktop)
     if _check_window_commands_available():
@@ -55,9 +68,9 @@ def _add_optional_commands(app: typer.Typer) -> None:
         app.add_typer(window.app, name="window", help="Window management commands")
     else:
         if platform.system() != "Windows":
-            logger.debug("Window commands disabled: not running on Windows")
+            _dependency_warnings.append("[dim]ℹ Window commands disabled: not running on Windows[/dim]")
         elif not importlib.util.find_spec("owa.env.desktop"):
-            logger.debug("Window commands disabled: owa.env.desktop not installed")
+            _dependency_warnings.append("[dim]ℹ Window commands disabled: owa.env.desktop not installed[/dim]")
 
 
 def _check_ffmpeg_available() -> bool:
@@ -70,13 +83,25 @@ def _check_window_commands_available() -> bool:
     return platform.system() == "Windows" and importlib.util.find_spec("owa.env.desktop") is not None
 
 
-def main() -> None:
+def callback(
+    silent: bool = typer.Option(False, "--silent", "-s", help="Suppress non-essential output"),
+    no_update_check: bool = typer.Option(False, "--no-update-check", help="Skip version update check"),
+) -> None:
     """Main CLI entry point with global options."""
-    check_for_update()
+    # Show dependency warnings (unless silent)
+    if not silent:
+        _show_dependency_warnings()
+
+    # Check for updates unless disabled
+    if not no_update_check:
+        check_for_update(silent=silent)
 
 
-# Create the main application
-app = create_app()
+def _show_dependency_warnings() -> None:
+    """Show warnings about missing optional dependencies."""
+    for warning in _dependency_warnings:
+        console.print(warning)
 
-# Add global options to the main command
-app.callback()(main)
+
+# Create the main application with callback
+app = create_app(callback=callback)

--- a/projects/owa-cli/owa/cli/__init__.py
+++ b/projects/owa-cli/owa/cli/__init__.py
@@ -6,22 +6,20 @@ including MCAP file management, video processing, and system utilities.
 """
 
 import importlib
+import importlib.util
 import platform
 import shutil
 
 # TODO?: replace to https://github.com/BrianPugh/cyclopts
 import typer
 from loguru import logger
-from rich.console import Console
 
 from . import env, mcap, messages, video
+from .console import console
 from .utils import check_for_update
 
 # Disable logger by default for library usage (following loguru best practices)
 logger.disable("owa.cli")
-
-# Console for user-facing messages
-console = Console()
 
 # Store warnings to show later
 _dependency_warnings = []

--- a/projects/owa-cli/owa/cli/console.py
+++ b/projects/owa-cli/owa/cli/console.py
@@ -1,0 +1,13 @@
+"""
+Shared console instance for OWA CLI.
+
+This module provides a centralized rich console instance that should be used
+across all owa-cli modules for consistent output formatting and styling.
+"""
+
+from rich.console import Console
+
+# Shared console instance for all CLI output
+console = Console()
+
+__all__ = ["console"]

--- a/projects/owa-cli/owa/cli/env/list.py
+++ b/projects/owa-cli/owa/cli/env/list.py
@@ -3,13 +3,12 @@ import sys
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
 from owa.core import get_component_info, list_components
 
-console = Console()
+from ..console import console
 
 
 def list_plugins(

--- a/projects/owa-cli/owa/cli/env/quick.py
+++ b/projects/owa-cli/owa/cli/env/quick.py
@@ -1,13 +1,11 @@
 """Quick access commands for common operations."""
 
 import typer
-from rich.console import Console
 
+from ..console import console
 from . import list as list_module
 from . import search as search_module
 from . import show as show_module
-
-console = Console()
 
 
 def ls(
@@ -18,7 +16,7 @@ def ls(
         # Show specific namespace with components
         show_module.show_plugin(
             namespace=namespace,
-            show_components=True,
+            components=True,
             component_type=None,
             search=None,
             details=False,
@@ -49,8 +47,9 @@ def find(
 
 def namespaces():
     """List all available namespaces."""
-    from owa.core import list_components
     from collections import Counter
+
+    from owa.core import list_components
 
     # Collect all namespaces
     all_namespaces = set()

--- a/projects/owa-cli/owa/cli/env/search.py
+++ b/projects/owa-cli/owa/cli/env/search.py
@@ -3,13 +3,12 @@ import sys
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
 from owa.core import get_component_info, list_components
 
-console = Console()
+from ..console import console
 
 
 def search_components(

--- a/projects/owa-cli/owa/cli/env/show.py
+++ b/projects/owa-cli/owa/cli/env/show.py
@@ -3,13 +3,12 @@ import sys
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
 from owa.core import get_component, get_component_info, list_components
 
-console = Console()
+from ..console import console
 
 
 def show_plugin(

--- a/projects/owa-cli/owa/cli/env/stats.py
+++ b/projects/owa-cli/owa/cli/env/stats.py
@@ -2,13 +2,12 @@ from collections import Counter
 from typing import Dict, List
 
 import typer
-from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
 from owa.core import get_component_info, list_components
 
-console = Console()
+from ..console import console
 
 
 def show_stats(

--- a/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
@@ -23,6 +23,8 @@ from owa.cli.mcap.migrate.file_utils import (
     format_file_size,
 )
 
+from ...console import console
+
 
 @dataclass
 class BackupFileInfo:
@@ -225,8 +227,6 @@ def cleanup(
         owl mcap migrate cleanup /path/to/backups  # Clean backup files in specific directory
         owl mcap migrate cleanup file.mcap         # Clean backup for specific MCAP file
     """
-    console = Console()
-
     # Set default patterns if none provided
     if patterns is None:
         patterns = ["**/*.mcap.backup"]

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_2_0_to_v0_3_0.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_2_0_to_v0_3_0.py
@@ -17,7 +17,9 @@
 MCAP Migrator: v0.2.0 → v0.3.0
 
 Migrates schema names from old format (owa_env_desktop) to new format (owa.env.desktop: implicit namespace packaging, PEP 420).
-Note: Before v0.3.2, mcap-owa-support version was 0.1.0, so this script must be run with manual user's decision.
+
+NOTE: Before v0.3.2, mcap-owa-support version was 0.1.0, so this script must be run with manual user's decision.
+NOTE: These migrators are locked, separate script with separate dependency sets. DO NOT change the contents unless you know what you are doing.
 """
 
 import importlib

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_3_0_to_v0_3_2.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_3_0_to_v0_3_2.py
@@ -17,7 +17,9 @@
 MCAP Migrator: v0.3.0 → v0.3.2
 
 Migrates keyboard state field from `pressed_vk_list` to `buttons`.
-Note: Before v0.3.2, mcap-owa-support version was 0.1.0, so this script must be run with manual user's decision.
+
+NOTE: Before v0.3.2, mcap-owa-support version was 0.1.0, so this script must be run with manual user's decision.
+NOTE: These migrators are locked, separate script with separate dependency sets. DO NOT change the contents unless you know what you are doing.
 """
 
 import importlib

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_3_2_to_v0_4_2.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_3_2_to_v0_4_2.py
@@ -19,6 +19,8 @@
 MCAP Migrator: v0.3.2 → v0.4.2
 
 Migrates schema format from module-based to domain-based. See OEP-0006.
+
+NOTE: These migrators are locked, separate script with separate dependency sets. DO NOT change the contents unless you know what you are doing.
 """
 
 from pathlib import Path

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_4_2_to_v0_5_0.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_4_2_to_v0_5_0.py
@@ -24,6 +24,8 @@ structured media reference system. Key changes:
 - `pts` → `pts_ns` (in ExternalVideoRef)
 - Simple path/pts fields → structured MediaRef system (EmbeddedRef, ExternalImageRef, ExternalVideoRef)
 - Enhanced media reference types with proper type discrimination
+
+NOTE: These migrators are locked, separate script with separate dependency sets. DO NOT change the contents unless you know what you are doing.
 """
 
 from pathlib import Path

--- a/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_5_0_to_v0_5_1.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/migrators/v0_5_0_to_v0_5_1.py
@@ -24,6 +24,8 @@ Key changes:
 - ExternalImageRef → MediaRef with path URI
 - ExternalVideoRef → MediaRef with path URI + pts_ns
 - Unified MediaRef class with computed properties
+
+NOTE: These migrators are locked, separate script with separate dependency sets. DO NOT change the contents unless you know what you are doing.
 """
 
 import shutil

--- a/projects/owa-cli/owa/cli/mcap/sanitize.py
+++ b/projects/owa-cli/owa/cli/mcap/sanitize.py
@@ -20,6 +20,8 @@ from typing_extensions import Annotated
 from mcap_owa.highlevel import OWAMcapReader, OWAMcapWriter
 from owa.cli.mcap.backup_utils import BackupContext
 
+from ..console import console
+
 
 @contextmanager
 def safe_temp_file(mode="wb", suffix=".mcap"):
@@ -237,7 +239,6 @@ def sanitize(
         owl mcap sanitize data.mcap --keep-window "Browser" --dry-run
         owl mcap sanitize data.mcap --keep-window "App" --max-removal-ratio 0.95
     """
-    console = Console()
 
     # Validate inputs
     if not files:

--- a/projects/owa-cli/owa/cli/messages/list.py
+++ b/projects/owa-cli/owa/cli/messages/list.py
@@ -8,6 +8,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..console import console
+
 try:
     from owa.core import MESSAGES
 except ImportError:
@@ -28,8 +30,6 @@ def list_messages(
     if MESSAGES is None:
         typer.echo("Error: owa.core not available. Please install owa-core package.", err=True)
         raise typer.Exit(1)
-
-    console = Console()
 
     # Get all message types
     try:

--- a/projects/owa-cli/owa/cli/messages/show.py
+++ b/projects/owa-cli/owa/cli/messages/show.py
@@ -10,6 +10,8 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
 
+from ..console import console
+
 try:
     from owa.core import MESSAGES
 except ImportError:
@@ -30,8 +32,6 @@ def show_message(
     if MESSAGES is None:
         typer.echo("Error: owa.core not available. Please install owa-core package.", err=True)
         raise typer.Exit(1)
-
-    console = Console()
 
     # Get the message class
     try:

--- a/projects/owa-cli/owa/cli/messages/validate.py
+++ b/projects/owa-cli/owa/cli/messages/validate.py
@@ -3,8 +3,9 @@ Validate command for message registry.
 """
 
 import typer
-from rich.console import Console
 from rich.table import Table
+
+from ..console import console
 
 try:
     from owa.core import MESSAGES
@@ -28,7 +29,6 @@ def validate_messages(
         typer.echo("Error: owa.core not available. Please install owa-core package.", err=True)
         raise typer.Exit(1)
 
-    console = Console()
     console.print("[bold blue]Validating Message Registry...[/bold blue]\n")
 
     # Validation results

--- a/projects/owa-cli/owa/cli/utils.py
+++ b/projects/owa-cli/owa/cli/utils.py
@@ -31,9 +31,13 @@ def get_latest_release() -> str:
     return tag.lstrip("v")  # Remove leading "v" if present
 
 
-def check_for_update(package_name: str = "owa.cli") -> bool:
+def check_for_update(package_name: str = "owa.cli", *, silent: bool = False) -> bool:
     """
     Check for updates and print a message if a new version is available.
+
+    Args:
+        package_name: Name of the package to check
+        silent: If True, suppress all output
 
     Returns:
         bool: True if the local version is up to date, False otherwise.
@@ -46,19 +50,24 @@ def check_for_update(package_name: str = "owa.cli") -> bool:
         local_version = get_local_version(package_name)
         latest_version = get_latest_release()
         if parse_version(latest_version) > parse_version(local_version):
-            print(f"""
+            if not silent:
+                print(f"""
 [bold red]******************************************************[/bold red]
 [bold yellow]   An update is available for Open World Agents![/bold yellow]
 [bold red]******************************************************[/bold red]
 [bold]  Your version:[/bold] [red]{local_version}[/red]    [bold]Latest:[/bold] [green]{latest_version}[/green]
   Get it here: [bold cyan]https://github.com/open-world-agents/open-world-agents/releases[/bold cyan]
 """)
+            return False
         else:
             return True
     except requests.Timeout as e:
-        print(f"[bold red]Error:[/bold red] Unable to check for updates. Timeout occurred: {e}")
+        if not silent:
+            print(f"[bold red]⚠ Error:[/bold red] Unable to check for updates. Timeout occurred: {e}")
     except requests.RequestException as e:
-        print(f"[bold red]Error:[/bold red] Unable to check for updates. Request failed: {e}")
+        if not silent:
+            print(f"[bold red]⚠ Error:[/bold red] Unable to check for updates. Request failed: {e}")
     except Exception as e:
-        print(f"[bold red]Error:[/bold red] Unable to check for updates. An unexpected error occurred: {e}")
+        if not silent:
+            print(f"[bold red]⚠ Error:[/bold red] Unable to check for updates. An unexpected error occurred: {e}")
     return False

--- a/projects/owa-cli/tests/test_no_api_calls.py
+++ b/projects/owa-cli/tests/test_no_api_calls.py
@@ -26,7 +26,7 @@ def test_no_github_api_calls_during_version_check():
 
     with patch("requests.get") as mock_get:
         # These should not make API calls due to environment variable
-        check_for_update()
+        check_for_update(silent=True)
         get_latest_mcap_cli_version()
 
         # Verify no API calls were made

--- a/projects/owa-core/owa/core/__init__.py
+++ b/projects/owa-core/owa/core/__init__.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from .auto_discovery import auto_discover_plugins
 from .callable import Callable
 from .component_access import get_component, get_component_info, list_components
@@ -8,6 +10,9 @@ from .plugin_discovery import discover_and_register_plugins, get_plugin_discover
 from .plugin_spec import PluginSpec
 from .registry import CALLABLES, LISTENERS, RUNNABLES, LazyImportRegistry, Registry
 from .runnable import Runnable
+
+# Disable logger by default for library usage (following loguru best practices)
+logger.disable("owa.core")
 
 # Automatically discover and register plugins on import
 auto_discover_plugins()

--- a/projects/owa-core/owa/core/io/__init__.py
+++ b/projects/owa-core/owa/core/io/__init__.py
@@ -1,5 +1,3 @@
-from loguru import logger
-
 from .image import load_image
 from .media import (
     bgra_array_to_pil,
@@ -10,8 +8,6 @@ from .media import (
     validate_media_path,
 )
 from .video import VideoReader, VideoWriter
-
-logger.disable("owa.core.io")
 
 __all__ = [
     "load_image",

--- a/projects/owa-core/owa/core/plugin_discovery.py
+++ b/projects/owa-core/owa/core/plugin_discovery.py
@@ -16,9 +16,6 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
-if not os.getenv("OWA_ENABLE_PLUGIN_DISCOVERY_LOGS", "false").lower() == "true":
-    logger.disable("owa.core.plugin_discovery")
-
 
 class PluginDiscovery:
     """

--- a/projects/owa-core/owa/core/plugin_discovery.py
+++ b/projects/owa-core/owa/core/plugin_discovery.py
@@ -1,7 +1,6 @@
 # ================ Entry Points-Based Plugin Discovery ================================
 # Implements automatic plugin discovery and registration using Python entry points
 
-import os
 import sys
 from typing import Dict, Optional, Union
 

--- a/projects/owa-core/owa/core/registry.py
+++ b/projects/owa-core/owa/core/registry.py
@@ -5,7 +5,7 @@
 
 import importlib
 from enum import StrEnum
-from typing import Dict, Generic, Optional, TypeVar
+from typing import Dict, Generic, Optional, Type, TypeVar, cast
 
 from .callable import Callable as CallableCls
 from .listener import Listener as ListenerCls
@@ -75,10 +75,10 @@ class LazyImportRegistry(Registry[T]):
         """
         if is_instance:
             # Register pre-loaded instance using base registry method
-            super().register(name, obj_or_import_path)
+            super().register(name, cast(T, obj_or_import_path))
         else:
             # Register for lazy loading
-            self._import_paths[name] = obj_or_import_path
+            self._import_paths[name] = cast(str, obj_or_import_path)
             if eager_load:
                 # Load immediately and store using base registry method
                 component = self._load_component(name)
@@ -141,6 +141,6 @@ class LazyImportRegistry(Registry[T]):
 
 
 # Now specify the types of the registries
-CALLABLES: LazyImportRegistry[CallableCls] = LazyImportRegistry(registry_type=RegistryType.CALLABLES)
-LISTENERS: LazyImportRegistry[ListenerCls] = LazyImportRegistry(registry_type=RegistryType.LISTENERS)
-RUNNABLES: LazyImportRegistry[Runnable] = LazyImportRegistry(registry_type=RegistryType.RUNNABLES)
+CALLABLES: LazyImportRegistry[Type[CallableCls]] = LazyImportRegistry(registry_type=RegistryType.CALLABLES)
+LISTENERS: LazyImportRegistry[Type[ListenerCls]] = LazyImportRegistry(registry_type=RegistryType.LISTENERS)
+RUNNABLES: LazyImportRegistry[Type[Runnable]] = LazyImportRegistry(registry_type=RegistryType.RUNNABLES)


### PR DESCRIPTION
This pull request introduces several improvements to the `owa-cli` project, focusing on enhancing code maintainability, consolidating shared functionality, and improving user experience. Key changes include the introduction of a shared `console` instance for consistent CLI output formatting, updates to dependency warnings and global options, and refinements to the `check_for_update` utility. Additionally, minor adjustments were made to improve clarity and ensure best practices.

### Shared functionality and consistency:
* [`projects/owa-cli/owa/cli/console.py`](diffhunk://#diff-18844f92dc7e2fb882e11e4eec48f5a3a37a5520fe929b5dab7a99d2ace516e9R1-R13): Added a centralized `console` instance using `rich.console.Console` for consistent output formatting across all CLI modules.
* Replaced individual `Console` instances with the shared `console` in various modules, including `env/list.py`, `env/quick.py`, `env/search.py`, `env/show.py`, `env/stats.py`, `mcap/migrate/cleanup.py`, `mcap/sanitize.py`, `messages/list.py`, `messages/show.py`, `messages/validate.py`. [[1]](diffhunk://#diff-c15f7e1f388c9465553851b71662280da2a757995e7a9716961d2afb99b50853L6-R11) [[2]](diffhunk://#diff-22227bbb666612235652fe0ac44d98337c90b436a2cd99a6ffc9d4a4dc6c9314L4-L11) [[3]](diffhunk://#diff-79e19e680a82bcce32417aaddbc4bffd56109b07f56ba246f7677fd238321b2eL6-R11) [[4]](diffhunk://#diff-b1b112fac5ef2c803920b353f83d6249290780620fe1ea487128845cb2583933L6-R11) [[5]](diffhunk://#diff-41f23476cc1a77a9dbbc1f5f1685dab536d643db33b3d83d324b250cf45c2adeL5-R10) [[6]](diffhunk://#diff-1a2918c281febecf0c369dad74ceb1e524675ba003e5d5e3403a297538b3fb7eR26-R27) [[7]](diffhunk://#diff-22cdc84b2d5d1783699c5296e366173ba672fecc1409f2b3806cce1a8a73c144R23-R24) [[8]](diffhunk://#diff-91bddedac87f08a41cb6dfcb8c39e243c2d00f5916d8549f424693eb90871709R11-R12) [[9]](diffhunk://#diff-dc30f116881201012235088982fa8b50bae8a357e2324118ac639482faf5c05dR13-R14) [[10]](diffhunk://#diff-c18726d8ae30b8b90e34515dc18c28d5759cf7624fd64f3d6981f79492dcdaa0L6-R9)

### Dependency warnings and global options:
* [`projects/owa-cli/owa/cli/__init__.py`](diffhunk://#diff-5b8dc95001ebc00eebae901648f55fdb2b9ca807caca3f79425899fa9fc5c6afL49-R60): Enhanced dependency warnings by storing them in `_dependency_warnings` and displaying them using the shared `console`. Added a `silent` option to suppress non-essential output and a `no_update_check` option to skip update checks. [[1]](diffhunk://#diff-5b8dc95001ebc00eebae901648f55fdb2b9ca807caca3f79425899fa9fc5c6afL49-R60) [[2]](diffhunk://#diff-5b8dc95001ebc00eebae901648f55fdb2b9ca807caca3f79425899fa9fc5c6afL73-R105)

### Utility improvements:
* [`projects/owa-cli/owa/cli/utils.py`](diffhunk://#diff-7423c33d0e6bf59b1a0ce7c15c55b5329e9735d896734f6c6c62a3d67ced17c0L34-R41): Updated `check_for_update` to include a `silent` parameter, allowing suppression of output when checking for updates. Improved error handling with conditional logging based on the `silent` flag. [[1]](diffhunk://#diff-7423c33d0e6bf59b1a0ce7c15c55b5329e9735d896734f6c6c62a3d67ced17c0L34-R41) [[2]](diffhunk://#diff-7423c33d0e6bf59b1a0ce7c15c55b5329e9735d896734f6c6c62a3d67ced17c0R53-R72)

### Minor refinements:
* Migrator scripts (`mcap/migrate/migrators`): Added explicit notes warning against modifying locked migrator scripts to ensure reliability and maintain integrity. [[1]](diffhunk://#diff-1332fc2884254f1725ace9f45c447eb2a736dcf135455b7c26ab2300fb808ecdL20-R22) [[2]](diffhunk://#diff-5e81a0908db55de6475413bbc4cdaf42795cf6fd6e6d558c66e7e6b0cd84e942L20-R22) [[3]](diffhunk://#diff-432061280e33f41ee315d9ad65fd9652d86bc6f6cc5a48fce71f1ef1c8c4e444R22-R23) [[4]](diffhunk://#diff-ad4c2f3efa521e29e01f94fc97ef5fd7f6349cd0e145d1f68a8e8dc82b45ad9cR27-R28) [[5]](diffhunk://#diff-5af8313b8d0428d6eeead87e5268e00d51e4cf9c72ad588c659eb39a70c64851R27-R28)
* Adjusted argument names and comments for clarity and adherence to best practices, such as disabling the logger by default for library usage. [[1]](diffhunk://#diff-5b8dc95001ebc00eebae901648f55fdb2b9ca807caca3f79425899fa9fc5c6afR18-R47) [[2]](diffhunk://#diff-22227bbb666612235652fe0ac44d98337c90b436a2cd99a6ffc9d4a4dc6c9314L21-R19)