### PR TITLE
feat(mcap): add multiple file support to info command

### DIFF
--- a/projects/owa-cli/owa/cli/env/docs.py
+++ b/projects/owa-cli/owa/cli/env/docs.py
@@ -10,13 +10,12 @@ import sys
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
 from owa.core.documentation import DocumentationValidator
 from owa.core.documentation.validator import PluginStatus
 
-console = Console()
+from ..console import console
 
 
 def docs(

--- a/projects/owa-cli/owa/cli/env/validate.py
+++ b/projects/owa-cli/owa/cli/env/validate.py
@@ -3,14 +3,13 @@ from pathlib import Path
 
 import typer
 import yaml
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
 from owa.core.plugin_spec import PluginSpec
 
-console = Console()
+from ..console import console
 
 
 def _detect_input_type(spec_input: str) -> str:

--- a/projects/owa-cli/owa/cli/mcap/info.py
+++ b/projects/owa-cli/owa/cli/mcap/info.py
@@ -25,7 +25,7 @@ MCAP_CLI_DOWNLOAD_URL_TEMPLATES = {
     "windows-amd64": "https://github.com/foxglove/mcap/releases/download/releases%2Fmcap-cli%2F{version}/mcap-windows-amd64.exe",
 }
 # Current version as fallback
-CURRENT_MCAP_CLI_VERSION = "v0.0.53"
+CURRENT_MCAP_CLI_VERSION = "v0.0.54"
 
 
 def get_mcap_info(file_path: Path) -> dict:

--- a/projects/owa-cli/owa/cli/mcap/info.py
+++ b/projects/owa-cli/owa/cli/mcap/info.py
@@ -5,11 +5,16 @@ import subprocess
 import sys
 import urllib.request
 from pathlib import Path
+from typing import List
 
 import requests
 import typer
 from packaging.version import parse as parse_version
 from typing_extensions import Annotated
+
+from mcap_owa.highlevel import OWAMcapReader
+
+from ..console import console
 
 # Template URLs for mcap CLI downloads - {version} will be replaced with actual version
 MCAP_CLI_DOWNLOAD_URL_TEMPLATES = {
@@ -21,6 +26,83 @@ MCAP_CLI_DOWNLOAD_URL_TEMPLATES = {
 }
 # Current version as fallback
 CURRENT_MCAP_CLI_VERSION = "v0.0.53"
+
+
+def get_mcap_info(file_path: Path) -> dict:
+    """Get MCAP file information using OWAMcapReader."""
+    with OWAMcapReader(file_path) as reader:
+        duration_ns = reader.end_time - reader.start_time
+        return {
+            "file_path": file_path,
+            "messages": reader.message_count,
+            "duration_seconds": duration_ns / 1e9,
+            "size_bytes": file_path.stat().st_size,
+            "channels": len(reader.topics),
+        }
+
+
+def format_duration(seconds: float) -> str:
+    """Format duration in seconds to human-readable format."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    elif seconds < 3600:
+        minutes = int(seconds // 60)
+        remaining_seconds = seconds % 60
+        return f"{minutes}m{remaining_seconds:.1f}s"
+    else:
+        hours = int(seconds // 3600)
+        remaining_minutes = int((seconds % 3600) // 60)
+        remaining_seconds = seconds % 60
+        return f"{hours}h{remaining_minutes}m{remaining_seconds:.1f}s"
+
+
+def format_size(bytes_size: int) -> str:
+    """Format file size in bytes to human-readable format."""
+    if bytes_size < 1024:
+        return f"{bytes_size} B"
+    elif bytes_size < 1024 * 1024:
+        return f"{bytes_size / 1024:.1f} KiB"
+    elif bytes_size < 1024 * 1024 * 1024:
+        return f"{bytes_size / (1024 * 1024):.1f} MiB"
+    else:
+        return f"{bytes_size / (1024 * 1024 * 1024):.1f} GiB"
+
+
+def print_summary(file_infos: List[dict]) -> None:
+    """Print summary of multiple MCAP files."""
+    if not file_infos:
+        console.print("No valid MCAP files found.")
+        return
+
+    # Calculate totals
+    total_messages = sum(info["messages"] for info in file_infos)
+    total_duration = sum(info["duration_seconds"] for info in file_infos)
+    total_size = sum(info["size_bytes"] for info in file_infos)
+    total_channels = sum(info["channels"] for info in file_infos)
+
+    console.print(f"Summary for {len(file_infos)} MCAP files:")
+    console.print(f"{'=' * 50}")
+    console.print(f"Total messages:  {total_messages:,}")
+    console.print(f"Total duration:  {format_duration(total_duration)}")
+    console.print(f"Total size:      {format_size(total_size)}")
+    console.print(f"Total channels:  {total_channels} (sum across all files)")
+    console.print(f"Files processed: {len(file_infos)}")
+    console.print()
+
+    # Show per-file breakdown
+    console.print("Per-file breakdown:")
+    console.print(f"{'File':<30} {'Messages':<12} {'Duration':<15} {'Size':<12} {'Channels':<8}")
+    console.print(f"{'-' * 30} {'-' * 12} {'-' * 15} {'-' * 12} {'-' * 8}")
+
+    for info in file_infos:
+        filename = info["file_path"].name
+        if len(filename) > 28:
+            filename = filename[:25] + "..."
+
+        console.print(
+            f"{filename:<30} {info['messages']:<12,} {format_duration(info['duration_seconds']):<15} "
+            f"{format_size(info['size_bytes']):<12} {info['channels']:<8}"
+        )
 
 
 def detect_system():
@@ -166,14 +248,16 @@ def download_mcap_cli(bin_dir: Path, force_upgrade: bool = False):
 
 
 def info(
-    mcap_path: Annotated[Path, typer.Argument(help="Path to the input .mcap file")],
+    mcap_paths: Annotated[List[Path], typer.Argument(help="Path(s) to the input .mcap file(s)")],
     force_upgrade: Annotated[
         bool, typer.Option("--force-upgrade", help="Force upgrade mcap CLI to latest version")
     ] = False,
 ):
-    """Display information about the .mcap file."""
-    if not mcap_path.exists():
-        raise FileNotFoundError(f"MCAP file not found: {mcap_path}")
+    """Display information about the .mcap file(s). Shows detailed info for single file, summary for multiple files."""
+    # Validate all files exist
+    for mcap_path in mcap_paths:
+        if not mcap_path.exists():
+            raise FileNotFoundError(f"MCAP file not found: {mcap_path}")
 
     # Detect Conda environment and get its bin directory
     bin_dir = get_conda_bin_dir()
@@ -181,18 +265,45 @@ def info(
     # Download or upgrade `mcap` CLI if needed
     download_mcap_cli(bin_dir, force_upgrade)
 
-    # Run `mcap info <mcap_path>`
     mcap_executable = bin_dir / ("mcap.exe" if os.name == "nt" else "mcap")
-    result = subprocess.run([mcap_executable, "info", str(mcap_path)], text=True, capture_output=True)
 
-    if result.returncode == 0:
-        print(result.stdout)
+    if len(mcap_paths) == 1:
+        # Single file: show detailed info (original behavior)
+        result = subprocess.run([mcap_executable, "info", str(mcap_paths[0])], text=True, capture_output=True)
+
+        if result.returncode == 0:
+            console.print(result.stdout)
+        else:
+            print(f"Error running mcap CLI: {result.stderr}", file=sys.stderr)
+            sys.exit(result.returncode)
     else:
-        print(f"Error running mcap CLI: {result.stderr}", file=sys.stderr)
-        sys.exit(result.returncode)
+        # Multiple files: show summary
+        file_infos = []
+        errors = []
+
+        for mcap_path in mcap_paths:
+            try:
+                file_info = get_mcap_info(mcap_path)
+                file_infos.append(file_info)
+            except Exception as e:
+                errors.append(f"Error processing {mcap_path}: {e}")
+
+        # Print any errors
+        if errors:
+            print("Errors encountered:", file=sys.stderr)
+            for error in errors:
+                print(f"  {error}", file=sys.stderr)
+            print(file=sys.stderr)
+
+        # Print summary if we have any valid files
+        if file_infos:
+            print_summary(file_infos)
+        else:
+            print("No valid MCAP files could be processed.", file=sys.stderr)
+            sys.exit(1)
 
 
 # Example usage:
 if __name__ == "__main__":
     test_path = Path("example.mcap")
-    info(test_path)
+    info([test_path])


### PR DESCRIPTION
## Summary

Enhances the `owl mcap info` command to support multiple MCAP files with clean summary output.

## Changes

### 🚀 New Features
- **Multiple file support**: `owl mcap info file1.mcap file2.mcap file3.mcap`
- **Smart output**: Detailed info for single file, summary for multiple files
- **Clean implementation**: Uses `OWAMcapReader` directly instead of parsing CLI output
- **Aggregated metrics**: Total messages, duration, size, and channels across all files
- **Per-file breakdown**: Tabular view of individual file statistics

### 🔧 Improvements
- **Consistent styling**: Use shared console from `owa.cli.console` across env commands
- **Proper error handling**: Errors go to stderr, results to stdout
- **Backward compatibility**: Single file behavior unchanged
- **Version bump**: Updated mcap CLI to v0.0.54

## Example Output

```bash
$ owl mcap info file1.mcap file2.mcap file3.mcap

Summary for 3 MCAP files:
==================================================
Total messages:  2,152
Total duration:  19.7s
Total size:      83.6 KiB
Total channels:  18 (sum across all files)
Files processed: 3

Per-file breakdown:
File                           Messages     Duration        Size         Channels
------------------------------ ------------ --------------- ------------ --------
0.4.2.mcap                     619          3.8s            25.0 KiB     6       
0.3.2.mcap                     669          5.5s            21.1 KiB     6       
example.mcap                   864          10.4s           37.5 KiB     6       
```

## Technical Details

- **Clean architecture**: ~80 lines of maintainable code
- **No CLI parsing**: Direct `OWAMcapReader` usage for reliability
- **Proper I/O**: stdout/stderr separation for scripting compatibility
- **Error resilience**: Processes valid files even if some fail

## Testing

✅ Single file (preserves existing behavior)
✅ Multiple files (new summary functionality)  
✅ Error handling (invalid/missing files)
✅ Mixed scenarios (some valid, some invalid files)

Resolves the request for multiple file support in `owl mcap info`.