### PR TITLE
feat: Add FFmpeg installation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           cache-number: '0'
           cache-suffix: 'release-ocap' # same as job name
           environment-file: 'projects/ocap/environment.yml'
+      
+      - name: Install conda packages to owa env
+        run: mamba install -y -n owa ffmpeg micromamba
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv


### PR DESCRIPTION
# Add FFmpeg installation to release workflow

## Summary

This PR adds FFmpeg installation to the release workflow to ensure FFmpeg is available in the packaged environment.

## Changes

- Added a new step in the release workflow to install FFmpeg and micromamba using mamba
- This ensures that FFmpeg is included in the conda environment that gets packed for release

## Details

The change adds the following step to `.github/workflows/release.yml`:
```yaml
- name: Install conda packages to owa env
  run: mamba install -y -n owa ffmpeg micromamba
```

This step is placed after the conda environment setup and before the uv setup, ensuring FFmpeg is available when the environment is packed for distribution.

## Testing

- The workflow will continue to run the existing test `ocap --help` to verify the installation works correctly
- FFmpeg will be included in the packed environment artifact

## Files Changed

- `.github/workflows/release.yml` - Added FFmpeg installation step

## Impact

This change ensures that FFmpeg dependencies are properly included in the release package, which may be required for certain functionality in the OCAP project.
