### PR TITLE
Add keyboard press and release tokens to hierarchical event encoder

### DIFF
--- a/projects/owa-data/owa/data/encoders/hierarchical_event_encoder.py
+++ b/projects/owa-data/owa/data/encoders/hierarchical_event_encoder.py
@@ -139,6 +139,8 @@ def _generate_vocab() -> Set[str]:
         "<EVENT_START>",
         "<EVENT_END>",
         "<KEYBOARD>",
+        "<press>",
+        "<release>",
         "<MOUSE>",
         # fake_image_placeholder deliberately excluded - it's not a real token
     ]


### PR DESCRIPTION
# Add keyboard press and release tokens to hierarchical event encoder

## Summary
This PR adds two new tokens (`<press>` and `<release>`) to the vocabulary of the hierarchical event encoder to enable more granular keyboard event encoding.

## Changes
- Added `<press>` token to the vocabulary in `_generate_vocab()` function
- Added `<release>` token to the vocabulary in `_generate_vocab()` function
- These tokens are positioned after the `<KEYBOARD>` token for logical grouping

## Motivation
The addition of these tokens allows for more detailed representation of keyboard interactions by distinguishing between key press and key release events. This granular encoding can be valuable for:

- More accurate event sequence modeling
- Better understanding of user interaction patterns
- Enhanced training data representation for keyboard-based actions

## Testing
- The changes are minimal and only add vocabulary tokens
- No breaking changes to existing functionality
- The tokens follow the existing naming convention with angle brackets

## Impact
- **Low risk**: Only adds new vocabulary tokens without modifying existing logic
- **Backward compatible**: Existing encoded data remains valid
- **Forward compatible**: New tokens can be used in future encoding implementations
