### PR TITLE
feat: completely remove old module-based message system support

### DIFF
--- a/oeps/oep-0006.md
+++ b/oeps/oep-0006.md
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Replaces: 5
 Created: 10-Jun-2025
-Post-History: 10-Jun-2025, 14-Jun-2025
+Post-History: 10-Jun-2025, 14-Jun-2025, 04-Sep-2025
 
 Abstract
 ========
@@ -207,17 +207,15 @@ Backwards Compatibility
 
 This OEP maintains full backward compatibility with existing OWA installations:
 
-**No Breaking Changes:**
-- Existing OWAMcap files remain fully compatible and can be read without modification
-- Current mcap-owa-support APIs continue to work unchanged
-- Existing message classes continue to function with their original import paths
-- All existing code continues to work without requiring immediate updates
+**Breaking Changes (as of v0.6.0):**
+- Old module-based message format (`owa.env.desktop.msg.*`) is no longer supported
+- Only domain-based message format (`domain/MessageType`) is supported
+- Legacy MCAP files must be converted using migration tools before use
 
 **Migration Path:**
-- Core OWA message types are available in the new `owa-msgs` package
-- Existing imports are maintained through compatibility shims in `owa.env.desktop.msg`
-- Users can migrate gradually at their own pace
-- Legacy MCAP files can be converted using the `owl mcap convert-legacy` command
+- Core OWA message types are available in the `owa-msgs` package
+- Legacy MCAP files can be converted using the `owl mcap migrate` command
+- All message types now use the domain-based naming convention
 
 **Additive Changes:**
 - New entry point-based message discovery system (optional to use)

--- a/projects/mcap-owa-support/tests/test_highlevel.py
+++ b/projects/mcap-owa-support/tests/test_highlevel.py
@@ -13,16 +13,16 @@ and use mock message types instead of importing from other packages.
 import warnings
 
 import pytest
-from owa.core.message import OWAMessage
 
 from mcap_owa.highlevel import OWAMcapReader, OWAMcapWriter
+from owa.core.message import OWAMessage
 
 
 # Mock message types for testing (instead of importing from other packages)
 class MockKeyboardEvent(OWAMessage):
     """Mock keyboard event for testing MCAP functionality."""
 
-    _type = "test.msg.KeyboardEvent"
+    _type = "test/KeyboardEvent"
     event_type: str
     vk: int
     timestamp: int = 0
@@ -31,7 +31,7 @@ class MockKeyboardEvent(OWAMessage):
 class MockMouseEvent(OWAMessage):
     """Mock mouse event for testing MCAP functionality."""
 
-    _type = "test.msg.MouseEvent"
+    _type = "test/MouseEvent"
     event_type: str
     button: str
     x: int
@@ -63,7 +63,7 @@ def test_write_and_read_messages(temp_mcap_file):
 
     # Suppress warnings only for reading mock messages and version compatibility
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Failed to import module for schema 'test.msg.*", UserWarning)
+        warnings.filterwarnings("ignore", "Domain-based message.*not found in registry.*", UserWarning)
         warnings.filterwarnings("ignore", "Reader version.*may not be compatible with writer version.*", UserWarning)
 
         with OWAMcapReader(file_path, decode_args={"return_dict_on_failure": True}) as reader:
@@ -91,7 +91,7 @@ def test_mcap_message_object(temp_mcap_file):
 
     # Suppress warnings only for reading mock messages and version compatibility
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Failed to import module for schema 'test.msg.*", UserWarning)
+        warnings.filterwarnings("ignore", "Domain-based message.*not found in registry.*", UserWarning)
         warnings.filterwarnings("ignore", "Reader version.*may not be compatible with writer version.*", UserWarning)
 
         with OWAMcapReader(file_path, decode_args={"return_dict_on_failure": True}) as reader:
@@ -103,7 +103,7 @@ def test_mcap_message_object(temp_mcap_file):
             assert msg.topic == topic
             assert msg.timestamp == 1000
             assert isinstance(msg.message, bytes)
-            assert msg.message_type == "test.msg.KeyboardEvent"
+            assert msg.message_type == "test/KeyboardEvent"
 
             # Test lazy decoded property
             decoded = msg.decoded
@@ -133,14 +133,14 @@ def test_schema_based_filtering(temp_mcap_file):
 
     # Suppress warnings only for reading mock messages and version compatibility
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Failed to import module for schema 'test.msg.*", UserWarning)
+        warnings.filterwarnings("ignore", "Domain-based message.*not found in registry.*", UserWarning)
         warnings.filterwarnings("ignore", "Reader version.*may not be compatible with writer version.*", UserWarning)
 
         with OWAMcapReader(file_path, decode_args={"return_dict_on_failure": True}) as reader:
             # Filter by schema name
-            keyboard_messages = [msg for msg in reader.iter_messages() if msg.message_type == "test.msg.KeyboardEvent"]
+            keyboard_messages = [msg for msg in reader.iter_messages() if msg.message_type == "test/KeyboardEvent"]
 
-            mouse_messages = [msg for msg in reader.iter_messages() if msg.message_type == "test.msg.MouseEvent"]
+            mouse_messages = [msg for msg in reader.iter_messages() if msg.message_type == "test/MouseEvent"]
 
             assert len(keyboard_messages) == 2
             assert keyboard_messages[0].decoded.event_type == "press"
@@ -169,7 +169,7 @@ def test_multiple_message_types(temp_mcap_file):
 
     # Suppress warnings only for reading mock messages and version compatibility
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Failed to import module for schema 'test.msg.*", UserWarning)
+        warnings.filterwarnings("ignore", "Domain-based message.*not found in registry.*", UserWarning)
         warnings.filterwarnings("ignore", "Reader version.*may not be compatible with writer version.*", UserWarning)
 
         with OWAMcapReader(file_path, decode_args={"return_dict_on_failure": True}) as reader:
@@ -179,14 +179,14 @@ def test_multiple_message_types(temp_mcap_file):
             # Check first message (keyboard)
             keyboard_msg = messages[0]
             assert keyboard_msg.topic == "/keyboard"
-            assert keyboard_msg.message_type == "test.msg.KeyboardEvent"
+            assert keyboard_msg.message_type == "test/KeyboardEvent"
             assert keyboard_msg.decoded.event_type == "press"
             assert keyboard_msg.decoded.vk == 65
 
             # Check second message (mouse)
             mouse_msg = messages[1]
             assert mouse_msg.topic == "/mouse"
-            assert mouse_msg.message_type == "test.msg.MouseEvent"
+            assert mouse_msg.message_type == "test/MouseEvent"
             assert mouse_msg.decoded.event_type == "move"
             assert mouse_msg.decoded.x == 150
             assert mouse_msg.decoded.y == 250


### PR DESCRIPTION
## Summary

This PR completely removes support for the old module-based message system (owa.env.desktop.msg.*) from the codebase, implementing the breaking changes outlined in OEP-0006.

## Changes Made

###  **Breaking Changes**
- **Removed backward compatibility code** from mcap-owa-support decoder
- **Simplified verify_type method** to only support domain-based format (domain/MessageType)
- **Updated OEP-0006** to reflect breaking changes as of v0.6.0

###  **Code Cleanup**
- Removed unused importlib imports and old module-based logic
- Simplified create_message_decoder to only handle domain-based format
- Made erify_type method behavior consistent (always raises on error, returns True on success)
- Updated all error messages and docstrings to reflect domain-based only approach

###  **Test Updates**
- Updated all test message types to use domain-based format
- Fixed warning suppression to properly catch intended warnings
- Updated test assertions to expect new message type format
- All tests now run with clean, warning-free output

###  **Documentation**
- Updated OEP-0006 backward compatibility section
- Added clear migration path documentation
- Updated post-history date

## Migration Path

Users with legacy MCAP files can still migrate using:
`ash
owl mcap migrate run legacy-file.mcap
`

The migration scripts maintain their own isolated environments and continue to support the old format for conversion purposes.

## Testing

-  All core tests pass (199 passed, 3 skipped)
-  All mcap-owa-support tests pass (13 passed, 0 warnings)
-  All message system integration tests pass (6 passed)
-  CLI functionality works correctly (including auto-detect feature)

## Impact

This change makes the codebase significantly cleaner and more maintainable by:
- Removing ~56 lines of legacy compatibility code
- Eliminating confusing dual-format support
- Providing clear, consistent error messages
- Ensuring all tests run without unwanted warnings

**BREAKING CHANGE**: Old module-based message format (owa.env.desktop.msg.*) is no longer supported. Only domain-based format (domain/MessageType) is supported. Legacy MCAP files must be converted using migration tools before use.