### PR TITLE
feat(mcap/trim): Add dual time reference support and preserve UTC timestamps

### DIFF
--- a/projects/owa-cli/tests/mcap/test_trim.py
+++ b/projects/owa-cli/tests/mcap/test_trim.py
@@ -183,7 +183,7 @@ def test_trim_success(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.return_value = (
@@ -209,7 +209,7 @@ def test_trim_with_custom_max_margin(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.return_value = (
@@ -244,7 +244,7 @@ def test_trim_error_handling(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.side_effect = ValueError("No MKV files found")
@@ -400,7 +400,7 @@ def test_trim_missing_subtitle_error(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.side_effect = MissingSubtitleError(tmp_path / "video.mkv")
@@ -420,7 +420,7 @@ def test_trim_with_auto_subtitle(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.return_value = (
@@ -445,7 +445,7 @@ def test_trim_range_exceeds_video_duration(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.side_effect = ValueError(
@@ -467,7 +467,7 @@ def test_trim_negative_start_time(tmp_path, cli_runner):
     output_mcap = tmp_path / "output.mcap"
 
     with (
-        patch("owa.cli.mcap.trim.convert_video_to_mcap_time", side_effect=lambda *args, **kwargs: args[1]),
+        patch("owa.cli.mcap.trim.get_video_to_mcap_offset", return_value=0),
         patch("owa.cli.mcap.trim.trim_recording") as mock_trim,
     ):
         mock_trim.side_effect = ValueError("Invalid start time: -5s. Start time cannot be negative.")


### PR DESCRIPTION
## Summary

This PR improves the `owl mcap trim` command with two major enhancements:

### 1. Dual Time Reference Support

The trim command now supports two mutually exclusive ways to specify time ranges:

**Video PTS-based (existing behavior, renamed options):**
```bash
owl mcap trim input.mcap output.mcap --video-start 10.0 --video-end 40.0
```

**MCAP recording-based (new):**
```bash
owl mcap trim input.mcap output.mcap --mcap-start 10.0 --mcap-end 40.0
```

### 2. Preserve Original UTC Timestamps

Fixed a bug where message timestamps in the trimmed MCAP were being reset to near-epoch values (1970-01-01). Now the original UTC timestamps are preserved correctly.

## Changes

### `trim.py`
- Renamed CLI options: `--start` → `--video-start`, `--duration` → computed from `--video-end`
- Added new CLI options: `--mcap-start`, `--mcap-end` for MCAP-relative time specification
- Added `convert_mcap_to_video_time()` helper function for time conversion
- Simplified `trim_recording()` signature to always use video PTS-based `start` and `duration`
- Fixed `cut_mcap()` to preserve original UTC timestamps (only `media_ref.pts_ns` is adjusted)

### `test_trim.py`
- Updated tests to use new CLI option names
- Fixed test assertions to expect preserved UTC timestamps

## Breaking Changes

| Before | After |
|--------|-------|
| `--start` | `--video-start` or `--mcap-start` |
| `--duration` | `--video-end` or `--mcap-end` |

## Validation Rules

- `--video-start`/`--video-end` and `--mcap-start`/`--mcap-end` are mutually exclusive
- Within each group, both start and end must be specified together
- End time must be greater than start time

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author