### PR TITLE
docs: fix cleanup CLI docstring to use working glob pattern

### DIFF
--- a/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
@@ -191,10 +191,10 @@ def cleanup(
     and removes them after confirmation. Use --dry-run to preview what would be deleted.
 
     Examples:
-        owl mcap migrate cleanup                              # Clean all backup files in current directory tree
-        owl mcap migrate cleanup "*.mcap.backup"             # Clean backup files in current directory only
-        owl mcap migrate cleanup "/path/to/backups/**/*.mcap.backup"  # Clean backups under a specific directory
-        owl mcap migrate cleanup file.mcap                    # Clean backup for specific MCAP file
+        owl mcap migrate cleanup                                      # Clean all backup files in current directory tree
+        owl mcap migrate cleanup "*.mcap.backup"                      # Clean backup files in current directory only
+        owl mcap migrate cleanup "/path/to/backups/**/*.mcap.backup"  # Clean all backup files recursively under a specific directory
+        owl mcap migrate cleanup file.mcap                            # Clean backup for specific MCAP file
     """
     # Set default patterns if none provided
     if patterns is None:

--- a/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
+++ b/projects/owa-cli/owa/cli/mcap/migrate/cleanup.py
@@ -191,10 +191,10 @@ def cleanup(
     and removes them after confirmation. Use --dry-run to preview what would be deleted.
 
     Examples:
-        owl mcap migrate cleanup                    # Clean all backup files in current directory tree
-        owl mcap migrate cleanup "*.mcap.backup"   # Clean backup files in current directory only
-        owl mcap migrate cleanup /path/to/backups  # Clean backup files in specific directory
-        owl mcap migrate cleanup file.mcap         # Clean backup for specific MCAP file
+        owl mcap migrate cleanup                              # Clean all backup files in current directory tree
+        owl mcap migrate cleanup "*.mcap.backup"             # Clean backup files in current directory only
+        owl mcap migrate cleanup "/path/to/backups/**/*.mcap.backup"  # Clean backups under a specific directory
+        owl mcap migrate cleanup file.mcap                    # Clean backup for specific MCAP file
     """
     # Set default patterns if none provided
     if patterns is None:


### PR DESCRIPTION
## 🎯 Purpose
- [x] Documentation/configuration update

## 📊 Changes

The docstring of \`owl mcap migrate cleanup\` listed
\`owl mcap migrate cleanup /path/to/backups\` as a working example, but
it never matched any files. \`find_backup_files_by_pattern\`'s else-branch
calls \`glob.glob\` on the bare path and then skips entries whose suffix
is not \`.mcap\`, so a directory argument always produced zero results
(verified empirically against a temp directory containing real
\`*.mcap.backup\` files).

This is pre-existing behavior unrelated to #241; the orphaned
\`find_all_backup_files\` helper that #241 removed was never wired into
the CLI (since 5a7ed66d).

Replace the broken example with an explicit recursive glob form that
matches what \`find_backup_files_by_pattern\` actually accepts.

## 🧪 Testing
- [x] Verified the new example matches files: \`glob.glob('/tmp/cleanup_test/**/*.mcap.backup', recursive=True)\` returns all three planted backups.
- [x] Verified the original example returned 0 hits.

## 🤔 Review Focus
- Whether quoting in the docstring is shell-correct on both bash/zsh and PowerShell. Quoted glob is needed to prevent shell expansion.