### PR TITLE
Fix lockless video server Docker builds

### DIFF
--- a/projects/video-decoding-server/Dockerfile
+++ b/projects/video-decoding-server/Dockerfile
@@ -27,9 +27,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Install dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    vuv install --frozen --no-install-project
+    vuv install --no-install-project
 
 # ======================= Copy the model repository =======================
 

--- a/projects/video-decoding-server/Dockerfile.full
+++ b/projects/video-decoding-server/Dockerfile.full
@@ -31,9 +31,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Install dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    vuv install --frozen --no-install-project
+    vuv install --no-install-project
 
 # or  install the dependencies manually
 # ADD . /app


### PR DESCRIPTION
## 🎯 Purpose

- [ ] New feature implementation
- [x] Bug fix
- [ ] Experimental code
- [x] Documentation/configuration update
- [ ] Refactoring

Restore the video-decoding-server Docker build path after #254 intentionally removed committed `uv.lock` files.

## 📊 Changes

- Remove the deleted `uv.lock` bind mount from both video server Dockerfiles.
- Remove `--frozen`, which requires an existing lockfile.
- Keep `virtual-uv`, `vuv install`, and `--no-install-project` unchanged.
- Let uv resolve from the mounted `pyproject.toml` under its configured `exclude-newer` cutoff.

Files modified:

- `projects/video-decoding-server/Dockerfile`
- `projects/video-decoding-server/Dockerfile.full`

## 🧪 Testing

- [x] Verified lockless resolution with `uv sync --project projects/video-decoding-server --dry-run --no-install-project`
- [x] Resolved 9 packages and produced the expected 5-package install plan
- [ ] Docker build not run; it requires Docker permission and the NVIDIA Triton base image

## 🤔 Review Focus

- Confirm that the dependency installation layer no longer assumes a committed lockfile.
- Confirm that retaining `vuv` preserves the shared Conda/virtualenv workflow.

## 📎 References

- Follow-up to #254
